### PR TITLE
fix: AOS scroll animations not triggering on Portfolio and Experience

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,25 @@
 @tailwind components;
 @tailwind utilities;
 
+/* AOS (Animate On Scroll) — animación solo cuando el observer dispara */
+@keyframes aosSlideUp {
+  from { opacity: 0; transform: translateY(30px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes aosFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+[data-aos="fade-up"].aos-animate {
+  animation: aosSlideUp 0.6s ease both;
+}
+
+[data-aos="fade-in"].aos-animate {
+  animation: aosFadeIn 0.6s ease both;
+}
+
 @layer utilities {
   @keyframes float {
     0%, 100% {

--- a/src/infrastructure/services/AnimationManager.ts
+++ b/src/infrastructure/services/AnimationManager.ts
@@ -11,14 +11,9 @@ export class AnimationManager {
   }
 
   private init(): void {
-    this.setupScrollAnimations();
     this.setupStatsAnimation();
     this.setupParallaxEffect();
     this.setupTypingEffect();
-  }
-
-  private setupScrollAnimations(): void {
-    AnimationUtils.animateOnScroll(this.animatedElements);
   }
 
   private setupStatsAnimation(): void {

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -16,13 +16,13 @@ import { useModal } from '../../application/context/ModalContext';
 
 const HomePage: React.FC = () => {
   const location = useLocation();
-  const { 
-    isLoginOpen, 
-    isRegisterOpen, 
+  const {
+    isLoginOpen,
+    isRegisterOpen,
     isProfileOpen,
     isOrdersOpen,
-    closeLogin, 
-    closeRegister, 
+    closeLogin,
+    closeRegister,
     closeProfile,
     closeOrders,
     switchToRegister,
@@ -30,7 +30,25 @@ const HomePage: React.FC = () => {
   } = useModal();
 
   useEffect(() => {
-    // Si venimos con un hash, hacer scroll a esa sección
+    const elements = document.querySelectorAll<Element>('[data-aos]');
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const delay = entry.target.getAttribute('data-aos-delay');
+            if (delay) (entry.target as HTMLElement).style.transitionDelay = `${delay}ms`;
+            entry.target.classList.add('aos-animate');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' }
+    );
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
     if (location.hash) {
       setTimeout(() => {
         const element = document.querySelector(location.hash);
@@ -40,7 +58,6 @@ const HomePage: React.FC = () => {
         }
       }, 100);
     } else {
-      // Si no hay hash, hacer scroll al inicio
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   }, [location]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,12 @@ export class AnimationUtils {
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
+          const delay = entry.target.getAttribute('data-aos-delay');
+          if (delay) {
+            (entry.target as HTMLElement).style.transitionDelay = `${delay}ms`;
+          }
           entry.target.classList.add('aos-animate');
+          observer.unobserve(entry.target);
         }
       });
     }, {


### PR DESCRIPTION
## Summary

- Mueve el `IntersectionObserver` de `AnimationManager` a un `useEffect` en `HomePage.tsx` con `disconnect()` en el cleanup — más confiable y sigue el ciclo de vida de React correctamente
- Elimina `setupScrollAnimations` de `AnimationManager` para evitar observers duplicados
- Actualiza `animateOnScroll` en `utils.ts` para leer `data-aos-delay` y llamar `unobserve` tras animar (fire-once)
- Reemplaza el enfoque `opacity: 0` inicial por `@keyframes` CSS (`aosSlideUp`, `aosFadeIn`) disparados por la clase `aos-animate` — el contenido siempre es visible aunque el observer no dispare

## Test plan

- [x] Verificar que Portfolio y Experiencia son visibles al cargar la página
- [x] Verificar que al hacer scroll hacia Portfolio aparece animación fade-up en las tarjetas
- [x] Verificar que al hacer scroll hacia Experiencia aparece animación en los items del timeline
- [x] Verificar que al hacer scroll hacia Contacto aparece animación en el formulario

🤖 Generated with [Claude Code](https://claude.com/claude-code)