### PR TITLE
fix: hardcoded Spanish strings in Contact form ignore selected language

### DIFF
--- a/src/presentation/components/Contact.tsx
+++ b/src/presentation/components/Contact.tsx
@@ -324,7 +324,7 @@ const Contact: React.FC = () => {
                 {isSubmitting ? (
                   <>
                     <i className="fas fa-spinner fa-spin text-xs"></i>
-                    Enviando...
+                    {t('contact.form.sending')}
                   </>
                 ) : (
                   <>
@@ -344,7 +344,7 @@ const Contact: React.FC = () => {
               {submitStatus === 'error' && (
                 <div className="mt-4 p-3 bg-red-50 text-red-700 text-sm rounded-lg border border-red-200 flex items-center gap-2 animate-fade-in">
                   <i className="fas fa-exclamation-circle"></i>
-                  Error al enviar el mensaje. Por favor intenta de nuevo.
+                  {t('contact.form.error')}
                 </div>
               )}
             </form>


### PR DESCRIPTION
## Summary

- Reemplaza `"Enviando..."` y el mensaje de error hardcodeados con `t('contact.form.sending')` y `t('contact.form.error')`
- Las claves ya existían en `es.json` y `en.json` — solo faltaba usarlas

## Test plan

- [x] Cambiar idioma a English, enviar el formulario y verificar que el botón muestra "Sending..." durante el envío
- [x] Simular error de red y verificar que el mensaje de error aparece en el idioma seleccionado

🤖 Generated with [Claude Code](https://claude.com/claude-code)