### PR TITLE
feat: load Inter and Lexend fonts from Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
     <meta name="geo.region" content="GT">
     <meta name="geo.placename" content="Guatemala">
     
+    <!-- Google Fonts: Inter (body) + Lexend (headings) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lexend:wght@400;500;600;700&display=swap" rel="stylesheet">
+
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     


### PR DESCRIPTION
## Summary

- Agrega `preconnect` a `fonts.googleapis.com` y `fonts.gstatic.com` para reducir latencia
- Carga Inter (300–700) y Lexend (400–700) con `display=swap` para evitar FOIT
- Antes el sitio caía en fuentes del sistema aunque `tailwind.config.js` define Inter y Lexend como fuentes primarias

## Test plan

- [x] Abrir el sitio y verificar en DevTools → Network que `fonts.googleapis.com` responde 200
- [x] Verificar en DevTools → Elements que `font-family` resuelve a `Inter` en el body y `Lexend` en los headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)