### PR TITLE
feat: migrate Font Awesome CDN to react-icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lexend:wght@400;500;600;700&display=swap" rel="stylesheet">
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     
     <!-- GitHub Pages SPA redirect script -->

--- a/src/infrastructure/services/AnimationManager.ts
+++ b/src/infrastructure/services/AnimationManager.ts
@@ -1,12 +1,9 @@
 import { DOMUtils, AnimationUtils, PerformanceUtils } from '../../utils';
 
 export class AnimationManager {
-  private animatedElements: NodeListOf<Element>;
   private statsAnimated: boolean = false;
 
   constructor() {
-    this.animatedElements = DOMUtils.querySelectorAll<Element>('[data-aos]');
-    
     this.init();
   }
 

--- a/src/presentation/components/CartModal.tsx
+++ b/src/presentation/components/CartModal.tsx
@@ -9,6 +9,8 @@ interface CartModalProps {
   onClose: () => void;
 }
 
+import { FaShoppingCart, FaList, FaCode, FaClock, FaTrash, FaEdit, FaFileInvoice, FaSpinner, FaCreditCard, FaEnvelope, FaShieldAlt } from 'react-icons/fa';
+
 const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
   const { items, totalAmount, updateQuantity, removeFromCart, clearCart } = useCart();
   const { isAuthenticated, user } = useAuth();
@@ -78,7 +80,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
       <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between p-6 border-b border-gray-lighter flex-shrink-0">
           <h2 className="text-2xl font-bold text-dark flex items-center gap-3">
-            <i className="fas fa-shopping-cart text-primary"></i> Mi Carrito
+            <FaShoppingCart className="text-primary" /> Mi Carrito
             {items.length > 0 && (
               <span className="text-sm font-normal bg-primary text-white px-3 py-1 rounded-full">
                 {items.length} {items.length === 1 ? 'servicio' : 'servicios'}
@@ -91,7 +93,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
         <div className="flex-1 overflow-y-auto p-6 min-h-0" style={{ flexBasis: '60%' }}>
           {items.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <i className="fas fa-shopping-cart text-8xl text-gray-light mb-6"></i>
+              <FaShoppingCart className="text-8xl text-gray-light mb-6" />
               <p className="text-xl text-gray-medium mb-6">Tu carrito está vacío</p>
               <button className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all" onClick={onClose}>
                 Explorar Servicios
@@ -102,7 +104,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
               {/* Título de la sección */}
               <div className="flex items-center justify-between pb-2 border-b-2 border-primary/20 sticky top-0 bg-white z-10 -mx-6 px-6 py-2">
                 <h3 className="text-base font-semibold text-dark flex items-center gap-2">
-                  <i className="fas fa-list text-primary"></i>
+                  <FaList className="text-primary" />
                   Servicios ({items.length})
                 </h3>
                 <span className="text-xs text-gray-medium bg-gray-100 px-3 py-1 rounded-full">
@@ -115,7 +117,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                   <div className="flex gap-3 mb-3">
                     {/* Icono del servicio */}
                     <div className="w-12 h-12 bg-gradient-primary rounded-lg flex items-center justify-center flex-shrink-0 shadow-sm">
-                      <i className="fas fa-code text-lg text-white"></i>
+                      <FaCode className="text-lg text-white" />
                     </div>
                     
                     {/* Información principal */}
@@ -130,7 +132,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                       {/* Delivery time */}
                       {item.product.deliveryTime && (
                         <div className="flex items-center gap-1.5 text-xs text-gray-medium">
-                          <i className="fas fa-clock"></i>
+                          <FaClock />
                           <span>{item.product.deliveryTime}</span>
                         </div>
                       )}
@@ -142,7 +144,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                       onClick={() => removeFromCart(item.product.id)}
                       title="Eliminar"
                     >
-                      <i className="fas fa-trash text-xs"></i>
+                      <FaTrash className="text-xs" />
                     </button>
                   </div>
                   
@@ -150,7 +152,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                   {item.customizations && (
                     <div className="bg-primary/5 border border-primary/20 rounded-lg p-2 mb-2">
                       <p className="text-xs text-gray-dark">
-                        <i className="fas fa-edit text-primary mr-1"></i>
+                        <FaEdit className="text-primary mr-1" />
                         <span className="font-medium">Personalización:</span> {item.customizations}
                       </p>
                     </div>
@@ -246,7 +248,7 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                 />
                 <div className="flex-1">
                   <div className="flex items-center gap-1.5 text-dark font-semibold text-xs">
-                    <i className="fas fa-file-invoice text-secondary text-xs"></i>
+                    <FaFileInvoice className="text-secondary text-xs" />
                     Solicitar cotización sin costo
                   </div>
                 </div>
@@ -273,24 +275,24 @@ const CartModal: React.FC<CartModalProps> = ({ isOpen, onClose }) => {
                 >
                   {isProcessing ? (
                     <>
-                      <i className="fas fa-spinner fa-spin"></i>
+                      <FaSpinner className="animate-spin" />
                       Procesando...
                     </>
                   ) : isQuoteMode ? (
                     <>
-                      <i className="fas fa-file-invoice"></i>
+                      <FaFileInvoice />
                       Solicitar Cotización
                     </>
                   ) : (
                     <>
-                      <i className="fas fa-credit-card"></i>
+                      <FaCreditCard />
                       Pagar ${totalAmount.toLocaleString()}
                     </>
                   )}
                 </button>
                 
                 <div className="flex items-center justify-center gap-2 text-xs text-gray-medium mt-2">
-                  <i className={`fas ${isQuoteMode ? 'fa-envelope' : 'fa-shield-alt'} ${isQuoteMode ? 'text-secondary' : 'text-success'}`}></i>
+                  {isQuoteMode ? <FaEnvelope className="text-secondary" /> : <FaShieldAlt className="text-success" />}
                   <span>{isQuoteMode ? 'Cotización por email' : 'Pago seguro'}</span>
                 </div>
               </div>

--- a/src/presentation/components/Contact.tsx
+++ b/src/presentation/components/Contact.tsx
@@ -1,4 +1,5 @@
 import React, { useState, FormEvent, useEffect, useRef } from 'react';
+import { FaEnvelope, FaPhone, FaMapMarkerAlt, FaClock, FaCheck, FaCopy, FaSpinner, FaPaperPlane, FaCheckCircle, FaExclamationCircle } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
 import { ClipboardUtils } from '../../utils';
 
@@ -159,22 +160,22 @@ const Contact: React.FC = () => {
 
   const contactInfo = [
     {
-      icon: 'fa-envelope',
+      icon: FaEnvelope,
       titleKey: 'contact.info.email',
       value: 'ju16jo@gmail.com'
     },
     {
-      icon: 'fa-phone',
+      icon: FaPhone,
       titleKey: 'contact.info.phone',
       value: '+502 3132-2197'
     },
     {
-      icon: 'fa-map-marker-alt',
+      icon: FaMapMarkerAlt,
       titleKey: 'contact.info.location',
       value: 'Guatemala'
     },
     {
-      icon: 'fa-clock',
+      icon: FaClock,
       titleKey: 'contact.info.availability',
       valueKey: 'contact.info.schedule'
     }
@@ -192,7 +193,7 @@ const Contact: React.FC = () => {
             {contactInfo.map((item) => (
               <div key={item.titleKey} className="flex items-center gap-3">
                 <div className="w-10 h-10 bg-gradient-primary rounded-lg flex items-center justify-center flex-shrink-0">
-                  <i className={`fas ${item.icon} text-sm text-white`}></i>
+                  <item.icon className="text-sm text-white" />
                 </div>
                 <div className="flex-1 min-w-0">
                   <h4 className="text-sm font-semibold text-gray-900">{t(item.titleKey)}</h4>
@@ -205,9 +206,9 @@ const Contact: React.FC = () => {
                         title={`${t('common.copied').replace('!', '')} ${t(item.titleKey).toLowerCase()}`}
                       >
                         {copiedField === item.titleKey ? (
-                          <i className="fas fa-check text-xs"></i>
+                          <FaCheck className="text-xs" />
                         ) : (
-                          <i className="fas fa-copy text-xs"></i>
+                          <FaCopy className="text-xs" />
                         )}
                       </button>
                     </div>
@@ -323,12 +324,12 @@ const Contact: React.FC = () => {
               >
                 {isSubmitting ? (
                   <>
-                    <i className="fas fa-spinner fa-spin text-xs"></i>
+                    <FaSpinner className="animate-spin text-xs" />
                     {t('contact.form.sending')}
                   </>
                 ) : (
                   <>
-                    <i className="fas fa-paper-plane text-xs"></i>
+                    <FaPaperPlane className="text-xs" />
                     {t('contact.form.submit')}
                   </>
                 )}
@@ -336,14 +337,14 @@ const Contact: React.FC = () => {
 
               {submitStatus === 'success' && (
                 <div className="mt-4 p-3 bg-green-50 text-green-700 text-sm rounded-lg border border-green-200 flex items-center gap-2 animate-fade-in">
-                  <i className="fas fa-check-circle"></i>
+                  <FaCheckCircle />
                   {t('contact.form.success')}
                 </div>
               )}
 
               {submitStatus === 'error' && (
                 <div className="mt-4 p-3 bg-red-50 text-red-700 text-sm rounded-lg border border-red-200 flex items-center gap-2 animate-fade-in">
-                  <i className="fas fa-exclamation-circle"></i>
+                  <FaExclamationCircle />
                   {t('contact.form.error')}
                 </div>
               )}

--- a/src/presentation/components/Experience.tsx
+++ b/src/presentation/components/Experience.tsx
@@ -11,6 +11,8 @@ import {
   SiGitlab,
   SiArgo
 } from 'react-icons/si';
+import { FaExternalLinkAlt } from 'react-icons/fa';
+import { faIconMap } from '../utils/faIconMap';
 import { GetExperiencesUseCase } from '../../domain/use-cases/GetExperiencesUseCase';
 import { ExperienceRepositoryImpl } from '../../infrastructure/repositories/ExperienceRepositoryImpl';
 import { ExperienceData } from '../../domain/entities/Experience';
@@ -147,7 +149,7 @@ const Experience: React.FC = () => {
                       <span className="text-lg">{item.countryFlag}</span>
                       <span>{item.company}</span>
                       {item.remote && <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">Remoto</span>}
-                      <i className="fas fa-external-link-alt text-xs opacity-50"></i>
+                      <FaExternalLinkAlt className="text-xs opacity-50" />
                     </a>
                   ) : (
                     <h4 className={`inline-flex items-center gap-2 text-base text-primary font-medium mb-3 ${isEven ? 'md:flex-row-reverse' : ''}`}>
@@ -186,7 +188,7 @@ const Experience: React.FC = () => {
             >
               <div className="flex items-start gap-4">
                 <div className="w-10 h-10 bg-white rounded-lg flex items-center justify-center shadow-sm flex-shrink-0 text-primary">
-                  <i className={`fas ${achievement.icon} text-lg`}></i>
+                  { (() => { const I = faIconMap[achievement.icon]; return I ? <I className="text-lg" /> : null; })() }
                 </div>
                 <div>
                   <h4 className="text-lg font-bold text-gray-900 mb-2">{achievement.title}</h4>

--- a/src/presentation/components/Footer.tsx
+++ b/src/presentation/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FaEnvelope, FaPhone, FaMapMarkerAlt, FaLinkedin, FaGithub, FaCheck, FaCopy } from 'react-icons/fa';
 import { ClipboardUtils } from '../../utils';
 
 const Footer: React.FC = () => {
@@ -36,9 +37,9 @@ const Footer: React.FC = () => {
     {
       titleKey: 'footer.contact',
       links: [
-        { icon: 'fas fa-envelope', text: 'ju16jo@gmail.com', href: 'mailto:ju16jo@gmail.com', copyable: true },
-        { icon: 'fas fa-phone', text: '+502 3132-2197', href: 'tel:+50231322197', copyable: true },
-        { icon: 'fas fa-map-marker-alt', text: 'Guatemala', href: '#', copyable: false }
+        { icon: <FaEnvelope />, text: 'ju16jo@gmail.com', href: 'mailto:ju16jo@gmail.com', copyable: true },
+        { icon: <FaPhone />, text: '+502 3132-2197', href: 'tel:+50231322197', copyable: true },
+        { icon: <FaMapMarkerAlt />, text: 'Guatemala', href: '#', copyable: false }
       ]
     }
   ];
@@ -52,13 +53,13 @@ const Footer: React.FC = () => {
             <p className="text-gray-light mb-4 font-light leading-relaxed">{t('footer.description')}</p>
             <div className="flex gap-4 mt-4">
               <a href="mailto:ju16jo@gmail.com" aria-label="Email" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
-                <i className="fas fa-envelope"></i>
+                <FaEnvelope />
               </a>
               <a href="https://www.linkedin.com/in/juan-jose-hernandez-gt/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
-                <i className="fab fa-linkedin"></i>
+                <FaLinkedin />
               </a>
               <a href="https://github.com/jose16-21" aria-label="GitHub" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
-                <i className="fab fa-github"></i>
+                <FaGithub />
               </a>
             </div>
           </div>
@@ -71,7 +72,7 @@ const Footer: React.FC = () => {
                     {'icon' in link ? (
                       <div className="flex items-center gap-2 justify-between group">
                         <span className="cursor-pointer transition-colors hover:text-secondary font-light">
-                          <i className={link.icon}></i> {link.text}
+                          {link.icon} {link.text}
                         </span>
                         {link.copyable && (
                           <button
@@ -80,9 +81,9 @@ const Footer: React.FC = () => {
                             title={`${t('common.copied').replace('!', '')} ${link.text}`}
                           >
                             {copiedField === `${section.titleKey}-${index}` ? (
-                              <i className="fas fa-check text-xs"></i>
+                              <FaCheck className="text-xs" />
                             ) : (
-                              <i className="fas fa-copy text-xs"></i>
+                              <FaCopy className="text-xs" />
                             )}
                           </button>
                         )}

--- a/src/presentation/components/Hero.tsx
+++ b/src/presentation/components/Hero.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { FaPaperPlane, FaBriefcase, FaCheckCircle, FaEnvelope, FaLinkedinIn, FaGithub, FaWhatsapp, FaChevronDown } from 'react-icons/fa';
+
 const Hero: React.FC = () => {
   const { t } = useTranslation();
   
@@ -71,14 +73,14 @@ const Hero: React.FC = () => {
                 href="#contacto"
                 className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-semibold rounded-lg shadow-lg shadow-primary/25 hover:shadow-xl hover:shadow-primary/30 hover:-translate-y-0.5 transition-all duration-300"
               >
-                <i className="fas fa-paper-plane text-sm"></i>
+                <FaPaperPlane className="text-sm" />
                 {t('hero.cta.startProject')}
               </a>
               <a
                 href="#portafolio"
                 className="inline-flex items-center gap-2 px-6 py-3 bg-white text-slate-700 font-semibold rounded-lg border border-slate-200 hover:border-primary hover:text-primary hover:-translate-y-0.5 transition-all duration-300"
               >
-                <i className="fas fa-briefcase text-sm"></i>
+                <FaBriefcase className="text-sm" />
                 {t('hero.cta.viewWork')}
               </a>
             </div>
@@ -101,15 +103,15 @@ const Hero: React.FC = () => {
                 {/* Especialidades */}
                 <div className="space-y-3 mb-6">
                   <div className="flex items-center gap-3 text-sm text-slate-600">
-                    <i className="fas fa-check-circle text-emerald-500"></i>
+                    <FaCheckCircle className="text-emerald-500" />
                     <span>{t('hero.specialties.architecture')}</span>
                   </div>
                   <div className="flex items-center gap-3 text-sm text-slate-600">
-                    <i className="fas fa-check-circle text-emerald-500"></i>
+                    <FaCheckCircle className="text-emerald-500" />
                     <span>{t('hero.specialties.devops')}</span>
                   </div>
                   <div className="flex items-center gap-3 text-sm text-slate-600">
-                    <i className="fas fa-check-circle text-emerald-500"></i>
+                    <FaCheckCircle className="text-emerald-500" />
                     <span>{t('hero.specialties.leadership')}</span>
                   </div>
                 </div>
@@ -120,7 +122,7 @@ const Hero: React.FC = () => {
                     href="mailto:ju16jo@gmail.com"
                     className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center hover:bg-primary hover:text-white transition-all text-slate-500"
                   >
-                    <i className="fas fa-envelope text-sm"></i>
+                    <FaEnvelope className="text-sm" />
                   </a>
                   <a
                     href="https://www.linkedin.com/in/juan-jose-hernandez-gt/"
@@ -128,7 +130,7 @@ const Hero: React.FC = () => {
                     rel="noopener noreferrer"
                     className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center hover:bg-[#0077B5] hover:text-white transition-all text-slate-500"
                   >
-                    <i className="fab fa-linkedin-in text-sm"></i>
+                    <FaLinkedinIn className="text-sm" />
                   </a>
                   <a
                     href="https://github.com/jose16-21"
@@ -136,7 +138,7 @@ const Hero: React.FC = () => {
                     rel="noopener noreferrer"
                     className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center hover:bg-slate-800 hover:text-white transition-all text-slate-500"
                   >
-                    <i className="fab fa-github text-sm"></i>
+                    <FaGithub className="text-sm" />
                   </a>
                   <a
                     href="https://wa.me/50231322197"
@@ -144,7 +146,7 @@ const Hero: React.FC = () => {
                     rel="noopener noreferrer"
                     className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center hover:bg-[#25D366] hover:text-white transition-all text-slate-500"
                   >
-                    <i className="fab fa-whatsapp text-sm"></i>
+                    <FaWhatsapp className="text-sm" />
                   </a>
                 </div>
               </div>
@@ -161,7 +163,7 @@ const Hero: React.FC = () => {
       <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-20">
         <a href="#servicios" className="flex flex-col items-center gap-1 text-slate-400 hover:text-primary transition-colors">
           <span className="text-xs font-medium tracking-wider uppercase">{t('hero.explore')}</span>
-          <i className="fas fa-chevron-down text-sm animate-bounce"></i>
+          <FaChevronDown className="text-sm animate-bounce" />
         </a>
       </div>
     </section>

--- a/src/presentation/components/LanguageSelector.tsx
+++ b/src/presentation/components/LanguageSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FaChevronDown, FaCheck } from 'react-icons/fa';
 
 const languages = [
   { code: 'en', name: 'English', flag: '🇺🇸' },
@@ -38,7 +39,7 @@ const LanguageSelector: React.FC = () => {
       >
         <span className="text-lg">{currentLanguage.flag}</span>
         <span className="hidden sm:inline">{currentLanguage.code.toUpperCase()}</span>
-        <i className={`fas fa-chevron-down text-xs transition-transform ${isOpen ? 'rotate-180' : ''}`}></i>
+        <FaChevronDown className={`text-xs transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>
 
       {isOpen && (
@@ -54,7 +55,7 @@ const LanguageSelector: React.FC = () => {
               <span className="text-lg">{lang.flag}</span>
               <span>{lang.name}</span>
               {i18n.language === lang.code && (
-                <i className="fas fa-check text-xs ml-auto text-primary"></i>
+                <FaCheck className="text-xs ml-auto text-primary" />
               )}
             </button>
           ))}

--- a/src/presentation/components/LoginModal.tsx
+++ b/src/presentation/components/LoginModal.tsx
@@ -8,6 +8,8 @@ interface LoginModalProps {
   onShowRegister: () => void;
 }
 
+import { FaSignInAlt, FaTimes, FaEnvelope, FaLock, FaSpinner } from 'react-icons/fa';
+
 const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -71,7 +73,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
           <div className="absolute bottom-0 left-0 w-full p-6 z-10">
             <div className="flex items-center gap-4">
               <div className="w-14 h-14 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center border border-white/20 shadow-2xl">
-                <i className="fas fa-sign-in-alt text-2xl text-white"></i>
+                <FaSignInAlt className="text-2xl text-white" />
               </div>
               <div>
                 <h2 className="text-2xl font-bold text-white">Bienvenido</h2>
@@ -85,7 +87,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
             onClick={handleClose}
             className="absolute top-4 right-4 w-10 h-10 bg-black/20 hover:bg-black/40 backdrop-blur-md rounded-full flex items-center justify-center transition-all text-white border border-white/10 z-20"
           >
-            <i className="fas fa-times text-lg"></i>
+            <FaTimes className="text-lg" />
           </button>
         </div>
 
@@ -95,7 +97,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
             <label className="block text-sm font-medium text-gray-700 mb-1.5">Email</label>
             <div className="relative">
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                <i className="fas fa-envelope"></i>
+                <FaEnvelope />
               </span>
               <input
                 type="email"
@@ -112,7 +114,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
             <label className="block text-sm font-medium text-gray-700 mb-1.5">Contraseña</label>
             <div className="relative">
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                <i className="fas fa-lock"></i>
+                <FaLock />
               </span>
               <input
                 type="password"
@@ -132,12 +134,12 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
           >
             {isLoading ? (
               <>
-                <i className="fas fa-spinner fa-spin"></i>
+                <FaSpinner className="animate-spin" />
                 Iniciando...
               </>
             ) : (
               <>
-                <i className="fas fa-sign-in-alt"></i>
+                <FaSignInAlt />
                 Iniciar Sesión
               </>
             )}

--- a/src/presentation/components/Navigation.tsx
+++ b/src/presentation/components/Navigation.tsx
@@ -5,6 +5,7 @@ import { useCart } from '../../application/hooks/useCart';
 import { useAuth } from '../../application/hooks/useAuth';
 import { useModal } from '../../application/context/ModalContext';
 import LanguageSelector from './LanguageSelector';
+import { FaUser, FaChevronUp, FaChevronDown, FaShoppingBag, FaSignOutAlt, FaShoppingCart } from 'react-icons/fa';
 
 const Navigation: React.FC = () => {
   const { t } = useTranslation();
@@ -109,20 +110,20 @@ const Navigation: React.FC = () => {
             ) : (
               <div className="relative hidden lg:block">
                 <button className="flex items-center gap-2 bg-white border border-gray-light text-primary px-4 py-2 rounded-lg cursor-pointer transition-all font-semibold text-sm hover:border-primary" onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}>
-                  <i className="fas fa-user"></i>
+                  <FaUser />
                   <span>{user?.firstName}</span>
-                  <i className={`fas fa-chevron-${isUserMenuOpen ? 'up' : 'down'} text-xs`}></i>
+                  {isUserMenuOpen ? <FaChevronUp className="text-xs" /> : <FaChevronDown className="text-xs" />}
                 </button>
                 {isUserMenuOpen && (
                   <div className="absolute top-full right-0 bg-white border border-gray-200 rounded-lg shadow-xl min-w-[200px] mt-2 overflow-hidden">
                     <a href="#profile" className="flex items-center gap-3 px-4 py-3 text-gray-dark no-underline transition-all border-b border-gray-lighter font-medium text-sm hover:bg-gray-lighter hover:text-primary" onClick={(e) => { e.preventDefault(); openProfile(); setIsUserMenuOpen(false); }}>
-                      <i className="fas fa-user w-4"></i>{t('nav.profile')}
+                      <FaUser className="w-4" />{t('nav.profile')}
                     </a>
                     <a href="#orders" className="flex items-center gap-3 px-4 py-3 text-gray-dark no-underline transition-all border-b border-gray-lighter font-medium text-sm hover:bg-gray-lighter hover:text-primary" onClick={(e) => { e.preventDefault(); openOrders(); setIsUserMenuOpen(false); }}>
-                      <i className="fas fa-shopping-bag w-4"></i>{t('nav.orders')}
+                      <FaShoppingBag className="w-4" />{t('nav.orders')}
                     </a>
                     <a href="#logout" className="flex items-center gap-3 px-4 py-3 text-gray-dark no-underline transition-all font-medium text-sm hover:bg-gray-lighter hover:text-error" onClick={(e) => { e.preventDefault(); logout(); setIsUserMenuOpen(false); }}>
-                      <i className="fas fa-sign-out-alt w-4"></i>{t('nav.logout')}
+                      <FaSignOutAlt className="w-4" />{t('nav.logout')}
                     </a>
                   </div>
                 )}
@@ -133,7 +134,7 @@ const Navigation: React.FC = () => {
               to="/carrito"
               className="relative bg-gradient-primary text-white rounded-lg w-11 h-11 flex items-center justify-center cursor-pointer transition-all hover:shadow-lg"
             >
-              <i className="fas fa-shopping-cart"></i>
+              <FaShoppingCart />
               {itemCount > 0 && (<span className="absolute -top-1 -right-1 bg-error text-white rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold">{itemCount}</span>)}
             </Link>
 

--- a/src/presentation/components/OrdersModal.tsx
+++ b/src/presentation/components/OrdersModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../../application/hooks/useAuth';
+import { FaShoppingBag } from 'react-icons/fa';
 
 interface Order {
   id: string;
@@ -31,14 +32,14 @@ const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-dark/80 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={onClose}>
       <div className="bg-white rounded-2xl shadow-2xl max-w-3xl w-full max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between p-6 border-b border-gray-lighter">
-          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><i className="fas fa-shopping-bag text-primary"></i> Mis Órdenes</h2>
+          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><FaShoppingBag className="text-primary" /> Mis Órdenes</h2>
           <button className="w-10 h-10 bg-gray-lighter hover:bg-gray-light rounded-full flex items-center justify-center text-gray-dark hover:text-dark transition-colors text-2xl" onClick={onClose}>&times;</button>
         </div>
         
         <div className="flex-1 overflow-y-auto p-6">
           {orders.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <i className="fas fa-shopping-bag text-8xl text-gray-light mb-6"></i>
+              <FaShoppingBag className="text-8xl text-gray-light mb-6" />
               <h3 className="text-2xl font-bold text-dark mb-2">No tienes órdenes aún</h3>
               <p className="text-gray-medium mb-6">Cuando realices tu primera compra, aparecerá aquí.</p>
               <button className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all" onClick={onClose}>

--- a/src/presentation/components/Portfolio.tsx
+++ b/src/presentation/components/Portfolio.tsx
@@ -3,6 +3,9 @@ import { GetProjectsUseCase } from '../../domain/use-cases/GetProjectsUseCase';
 import { ProjectRepositoryImpl } from '../../infrastructure/repositories/ProjectRepositoryImpl';
 import { Project } from '../../domain/entities/Project';
 
+import { FaExternalLinkAlt } from 'react-icons/fa';
+import { faIconMap } from '../utils/faIconMap';
+
 const Portfolio: React.FC = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
@@ -63,7 +66,7 @@ const Portfolio: React.FC = () => {
                 ) : (
                   <div className="w-full h-full bg-gradient-primary flex items-center justify-center">
                     <div className="w-16 h-16 bg-white/20 rounded-xl flex items-center justify-center backdrop-blur-sm">
-                      <i className={`fas ${project.icon} text-4xl text-white`}></i>
+                      { (() => { const I = faIconMap[project.icon]; return I ? <I className="text-4xl text-white" /> : null; })() }
                     </div>
                   </div>
                 )}
@@ -84,7 +87,7 @@ const Portfolio: React.FC = () => {
                       className="ml-2 text-primary hover:text-dark transition-colors"
                       title="Ver proyecto"
                     >
-                      <i className="fas fa-external-link-alt text-sm"></i>
+                      <FaExternalLinkAlt className="text-sm" />
                     </a>
                   )}
                 </div>

--- a/src/presentation/components/ProfileModal.tsx
+++ b/src/presentation/components/ProfileModal.tsx
@@ -7,6 +7,8 @@ interface ProfileModalProps {
   onClose: () => void;
 }
 
+import { FaUser, FaEnvelope, FaBuilding, FaPhone, FaCalendar, FaEdit, FaSave } from 'react-icons/fa';
+
 const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
   const { user } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
@@ -61,7 +63,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-dark/80 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={handleClose}>
       <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between p-6 border-b border-gray-lighter sticky top-0 bg-white z-10">
-          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><i className="fas fa-user text-primary"></i> Mi Perfil</h2>
+          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><FaUser className="text-primary" /> Mi Perfil</h2>
           <button className="w-10 h-10 bg-gray-lighter hover:bg-gray-light rounded-full flex items-center justify-center text-gray-dark hover:text-dark transition-colors text-2xl" onClick={handleClose}>&times;</button>
         </div>
         
@@ -70,33 +72,33 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
             <div>
               <div className="flex flex-col items-center mb-8">
                 <div className="w-24 h-24 bg-gradient-primary rounded-full flex items-center justify-center mb-4">
-                  <i className="fas fa-user text-4xl text-white"></i>
+                  <FaUser className="text-4xl text-white" />
                 </div>
                 <h3 className="text-2xl font-bold text-dark">{user.firstName} {user.lastName}</h3>
               </div>
 
               <div className="space-y-4 mb-6">
                 <div className="bg-gray-lighter rounded-lg p-4">
-                  <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><i className="fas fa-envelope text-primary"></i> Email</label>
+                  <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><FaEnvelope className="text-primary" /> Email</label>
                   <p className="text-dark">{user.email}</p>
                 </div>
                 
                 {user.company && (
                   <div className="bg-gray-lighter rounded-lg p-4">
-                    <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><i className="fas fa-building text-primary"></i> Empresa</label>
+                    <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><FaBuilding className="text-primary" /> Empresa</label>
                     <p className="text-dark">{user.company}</p>
                   </div>
                 )}
                 
                 {user.phone && (
                   <div className="bg-gray-lighter rounded-lg p-4">
-                    <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><i className="fas fa-phone text-primary"></i> Teléfono</label>
+                    <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><FaPhone className="text-primary" /> Teléfono</label>
                     <p className="text-dark">{user.phone}</p>
                   </div>
                 )}
 
                 <div className="bg-gray-lighter rounded-lg p-4">
-                  <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><i className="fas fa-calendar text-primary"></i> Miembro desde</label>
+                  <label className="flex items-center gap-2 text-gray-dark font-medium mb-2"><FaCalendar className="text-primary" /> Miembro desde</label>
                   <p className="text-dark">{user.createdAt ? new Date(user.createdAt).toLocaleDateString('es-ES') : 'N/A'}</p>
                 </div>
               </div>
@@ -105,7 +107,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
                 className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all"
                 onClick={() => setIsEditing(true)}
               >
-                <i className="fas fa-edit"></i>
+                <FaEdit />
                 Editar Perfil
               </button>
             </div>
@@ -188,7 +190,7 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
                   Cancelar
                 </button>
                 <button type="submit" className="flex-1 inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all">
-                  <i className="fas fa-save"></i>
+                  <FaSave />
                   Guardar Cambios
                 </button>
               </div>

--- a/src/presentation/components/RegisterModal.tsx
+++ b/src/presentation/components/RegisterModal.tsx
@@ -8,6 +8,8 @@ interface RegisterModalProps {
   onShowLogin: () => void;
 }
 
+import { FaUserPlus, FaTimes, FaUser, FaEnvelope, FaLock, FaBuilding, FaPhone, FaSpinner } from 'react-icons/fa';
+
 const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLogin }) => {
   const [formData, setFormData] = useState({
     firstName: '',
@@ -134,7 +136,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
           <div className="absolute bottom-0 left-0 w-full p-5 z-10">
             <div className="flex items-center gap-4">
               <div className="w-12 h-12 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center border border-white/20 shadow-2xl">
-                <i className="fas fa-user-plus text-xl text-white"></i>
+                <FaUserPlus className="text-xl text-white" />
               </div>
               <div>
                 <h2 className="text-xl font-bold text-white">Crear Cuenta</h2>
@@ -148,7 +150,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
             onClick={handleClose}
             className="absolute top-4 right-4 w-10 h-10 bg-black/20 hover:bg-black/40 backdrop-blur-md rounded-full flex items-center justify-center transition-all text-white border border-white/10 z-20"
           >
-            <i className="fas fa-times text-lg"></i>
+            <FaTimes className="text-lg" />
           </button>
         </div>
 
@@ -160,7 +162,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               <label className="block text-sm font-medium text-gray-700 mb-1">Nombre</label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-user text-xs"></i>
+                  <FaUser className="text-xs" />
                 </span>
                 <input
                   type="text"
@@ -177,7 +179,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               <label className="block text-sm font-medium text-gray-700 mb-1">Apellido</label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-user text-xs"></i>
+                  <FaUser className="text-xs" />
                 </span>
                 <input
                   type="text"
@@ -197,7 +199,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
             <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
             <div className="relative">
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                <i className="fas fa-envelope text-xs"></i>
+                <FaEnvelope className="text-xs" />
               </span>
               <input
                 type="email"
@@ -217,7 +219,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               <label className="block text-sm font-medium text-gray-700 mb-1">Contraseña</label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-lock text-xs"></i>
+                  <FaLock className="text-xs" />
                 </span>
                 <input
                   type="password"
@@ -234,7 +236,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               <label className="block text-sm font-medium text-gray-700 mb-1">Confirmar</label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-lock text-xs"></i>
+                  <FaLock className="text-xs" />
                 </span>
                 <input
                   type="password"
@@ -257,7 +259,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               </label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-building text-xs"></i>
+                  <FaBuilding className="text-xs" />
                 </span>
                 <input
                   type="text"
@@ -275,7 +277,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
               </label>
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-                  <i className="fas fa-phone text-xs"></i>
+                  <FaPhone className="text-xs" />
                 </span>
                 <input
                   type="tel"
@@ -296,12 +298,12 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
           >
             {isLoading ? (
               <>
-                <i className="fas fa-spinner fa-spin"></i>
+                <FaSpinner className="animate-spin" />
                 Creando cuenta...
               </>
             ) : (
               <>
-                <i className="fas fa-user-plus"></i>
+                <FaUserPlus />
                 Crear Cuenta
               </>
             )}

--- a/src/presentation/components/ServiceDetailModal.tsx
+++ b/src/presentation/components/ServiceDetailModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Service } from '../../domain/entities/Service';
+import { faIconMap } from '../utils/faIconMap';
 
 interface ServiceDetailModalProps {
   isOpen: boolean;
@@ -7,6 +8,8 @@ interface ServiceDetailModalProps {
   service: Service | null;
   onAddToCart?: (service: Service) => void;
 }
+
+import { FaStar, FaTimes, FaInfoCircle, FaCheckDouble, FaCheck, FaLayerGroup, FaClock, FaShoppingCart, FaPaperPlane, FaCheckCircle, FaTimesCircle } from 'react-icons/fa';
 
 const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
   isOpen,
@@ -57,7 +60,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
           <div className="absolute bottom-0 left-0 w-full p-6 md:p-8 z-10">
             <div className="flex flex-col md:flex-row md:items-end gap-4">
               <div className="w-16 h-16 md:w-18 md:h-18 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center border border-white/20 shadow-2xl flex-shrink-0">
-                <i className={`fas ${service.icon} text-3xl text-white`}></i>
+                { (() => { const I = faIconMap[service.icon]; return I ? <I className="text-3xl text-white" /> : null; })() }
               </div>
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-2">
@@ -66,7 +69,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                   </span>
                   {service.featured && (
                     <span className="px-2.5 py-1 bg-accent/90 backdrop-blur-sm text-white text-xs font-bold uppercase tracking-wider rounded-full flex items-center gap-1">
-                      <i className="fas fa-star text-[10px]"></i> Popular
+                      <FaStar className="text-[10px]" /> Popular
                     </span>
                   )}
                 </div>
@@ -81,7 +84,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
             onClick={onClose}
             className="absolute top-6 right-6 w-10 h-10 bg-black/20 hover:bg-black/40 backdrop-blur-md rounded-full flex items-center justify-center transition-all text-white border border-white/10 z-20"
           >
-            <i className="fas fa-times text-lg"></i>
+            <FaTimes className="text-lg" />
           </button>
         </div>
 
@@ -93,7 +96,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               {/* Descripción completa */}
               <div>
                 <h3 className="text-xl font-bold text-dark mb-3 flex items-center gap-2">
-                  <i className="fas fa-info-circle text-primary"></i>
+                  <FaInfoCircle className="text-primary" />
                   Descripción Detallada
                 </h3>
                 <p className="text-gray-dark leading-relaxed">{service.description}</p>
@@ -102,7 +105,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               {/* Características completas */}
               <div>
                 <h3 className="text-xl font-bold text-dark mb-4 flex items-center gap-2">
-                  <i className="fas fa-check-double text-secondary"></i>
+                  <FaCheckDouble className="text-secondary" />
                   Características Incluidas
                 </h3>
                 <ul className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -111,7 +114,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                       key={index}
                       className="flex items-start gap-2 text-sm text-gray-dark bg-gray-50 p-3 rounded-lg border border-gray-100"
                     >
-                      <i className="fas fa-check text-success mt-0.5 flex-shrink-0"></i>
+                      <FaCheck className="text-success mt-0.5 flex-shrink-0" />
                       <span>{feature}</span>
                     </li>
                   ))}
@@ -121,7 +124,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               {/* Tecnologías */}
               <div>
                 <h3 className="text-xl font-bold text-dark mb-4 flex items-center gap-2">
-                  <i className="fas fa-layer-group text-accent"></i>
+                  <FaLayerGroup className="text-accent" />
                   Tecnologías Utilizadas
                 </h3>
                 <div className="flex flex-wrap gap-2">
@@ -152,7 +155,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
 
                 {service.deliveryTime && (
                   <div className="flex items-center justify-center gap-2 text-gray-dark text-sm bg-white p-3 rounded-lg border border-gray-200 mb-4">
-                    <i className="fas fa-clock text-primary"></i>
+                    <FaClock className="text-primary" />
                     <span className="font-medium">Entrega: {service.deliveryTime}</span>
                   </div>
                 )}
@@ -163,7 +166,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                       onClick={handleAddToCart}
                       className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-gradient-primary text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-300"
                     >
-                      <i className="fas fa-shopping-cart"></i>
+                      <FaShoppingCart />
                       Agregar al Carrito
                     </button>
                   )}
@@ -172,7 +175,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                     onClick={handleContactService}
                     className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-white text-primary font-semibold rounded-xl border-2 border-primary hover:bg-primary hover:text-white hover:scale-105 transition-all duration-300"
                   >
-                    <i className="fas fa-paper-plane"></i>
+                    <FaPaperPlane />
                     Contactar Ahora
                   </button>
                 </div>
@@ -181,7 +184,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               {/* Disponibilidad */}
               <div className={`p-4 rounded-xl border-2 ${service.available ? 'bg-success/10 border-success/30' : 'bg-gray-100 border-gray-300'}`}>
                 <div className="flex items-center gap-2 justify-center">
-                  <i className={`fas ${service.available ? 'fa-check-circle text-success' : 'fa-times-circle text-gray-500'}`}></i>
+                  {service.available ? <FaCheckCircle className="text-success" /> : <FaTimesCircle className="text-gray-500" />}
                   <span className={`font-semibold ${service.available ? 'text-success' : 'text-gray-500'}`}>
                     {service.available ? 'Disponible Ahora' : 'No Disponible'}
                   </span>

--- a/src/presentation/components/Services.tsx
+++ b/src/presentation/components/Services.tsx
@@ -6,6 +6,8 @@ import { GetServicesUseCase } from '../../domain/use-cases/GetServicesUseCase';
 import { useCart } from '../../application/hooks/useCart';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
 import ServiceDetailModal from './ServiceDetailModal';
+import { FaTh, FaChevronLeft, FaChevronRight, FaStar, FaCheck, FaClock, FaInfoCircle, FaCartPlus, FaInbox } from 'react-icons/fa';
+import { faIconMap } from '../utils/faIconMap';
 import { CategoryConfig } from '../../domain/repositories/ServiceRepository';
 
 const Services: React.FC = () => {
@@ -90,7 +92,7 @@ const Services: React.FC = () => {
                   }`}
                 onClick={() => setFilter('all')}
               >
-                <i className="fas fa-th text-xs"></i>
+                <FaTh className="text-xs" />
                 <span className="hidden sm:inline">{t('services.categories.all')}</span>
               </button>
 
@@ -104,7 +106,7 @@ const Services: React.FC = () => {
                   onClick={() => setFilter(config.id)}
                   title={config.label}
                 >
-                  <i className={`fas ${config.icon} text-xs`}></i>
+                  { (() => { const I = faIconMap[config.icon]; return I ? <I className="text-xs" /> : null; })() }
                   <span className="hidden sm:inline">{config.label}</span>
                 </button>
               ))}
@@ -113,9 +115,9 @@ const Services: React.FC = () => {
           {/* Indicador de scroll en móvil */}
           <div className="md:hidden text-center mt-2">
             <span className="text-xs text-gray-medium">
-              <i className="fas fa-chevron-left mr-1"></i>
+              <FaChevronLeft className="mr-1" />
               {t('services.swipeMore')}
-              <i className="fas fa-chevron-right ml-1"></i>
+              <FaChevronRight className="ml-1" />
             </span>
           </div>
         </div>
@@ -148,12 +150,12 @@ const Services: React.FC = () => {
 
                     <div className="absolute inset-0 p-4 md:p-6 flex items-center justify-between z-10">
                       <div className="w-10 h-10 md:w-14 md:h-14 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center border border-white/20 shadow-lg">
-                        <i className={`fas ${service.icon} text-xl md:text-2xl text-white`}></i>
+                        { (() => { const I = faIconMap[service.icon]; return I ? <I className="text-xl md:text-2xl text-white" /> : null; })() }
                       </div>
 
                       {service.featured && (
                         <div className="bg-accent/90 backdrop-blur-sm text-white px-3 py-1.5 rounded-full text-xs font-bold flex items-center gap-1.5 shadow-lg">
-                          <i className="fas fa-star text-[10px]"></i>
+                          <FaStar className="text-[10px]" />
                           {t('services.popular')}
                         </div>
                       )}
@@ -176,7 +178,7 @@ const Services: React.FC = () => {
                           key={index}
                           className="flex items-start gap-2 text-xs md:text-sm text-gray-dark"
                         >
-                          <i className="fas fa-check text-success mt-0.5 md:mt-1 text-xs flex-shrink-0"></i>
+                          <FaCheck className="text-success mt-0.5 md:mt-1 text-xs flex-shrink-0" />
                           <span className="line-clamp-1">{feature}</span>
                         </li>
                       ))}
@@ -197,7 +199,7 @@ const Services: React.FC = () => {
                           </div>
                           {service.deliveryTime && (
                             <div className="flex items-center gap-1 md:gap-1.5 text-gray-medium text-xs bg-white px-1.5 md:px-2 py-1 rounded-lg border border-gray-200">
-                              <i className="fas fa-clock text-xs"></i>
+                              <FaClock className="text-xs" />
                               <span className="hidden sm:inline">{service.deliveryTime}</span>
                             </div>
                           )}
@@ -227,14 +229,14 @@ const Services: React.FC = () => {
                         className="flex-1 bg-white text-primary font-semibold rounded-lg border-2 border-primary py-2 text-xs"
                         onClick={() => handleViewDetails(service)}
                       >
-                        <i className="fas fa-info-circle mr-1"></i>
+                        <FaInfoCircle className="mr-1" />
                         {t('services.details')}
                       </button>
                       <button
                         className="flex-1 bg-gradient-primary text-white font-semibold rounded-lg py-2 text-xs"
                         onClick={() => handleAddToCart(service)}
                       >
-                        <i className="fas fa-cart-plus mr-1"></i>
+                        <FaCartPlus className="mr-1" />
                         {t('services.addToCart')}
                       </button>
                     </div>
@@ -258,7 +260,7 @@ const Services: React.FC = () => {
         )}
         {!loading && services.length === 0 && (
           <div className="text-center py-12">
-            <i className="fas fa-inbox text-6xl text-gray-light mb-4"></i>
+            <FaInbox className="text-6xl text-gray-light mb-4" />
             <p className="text-xl text-gray-medium">{t('services.noServices')}</p>
           </div>
         )}

--- a/src/presentation/pages/CartPage.tsx
+++ b/src/presentation/pages/CartPage.tsx
@@ -1,3 +1,5 @@
+import { FaArrowLeft, FaShoppingCart, FaTrash, FaSearch, FaList, FaClock, FaEdit, FaReceipt, FaShoppingBag, FaTags, FaCommentAlt, FaFileInvoice, FaInfoCircle, FaSignInAlt, FaSpinner, FaCreditCard, FaCheck, FaCcVisa, FaCcMastercard, FaCcPaypal, FaCcAmex, FaEnvelope, FaShieldAlt } from 'react-icons/fa';
+import { faIconMap } from '../utils/faIconMap';
 import React, { useState } from 'react';
 import { useCart } from '../../application/hooks/useCart';
 import { useAuth } from '../../application/hooks/useAuth';
@@ -82,14 +84,14 @@ const CartPage: React.FC = () => {
             to="/"
             className="inline-flex items-center gap-2 text-gray-600 hover:text-primary transition-colors mb-4"
           >
-            <i className="fas fa-arrow-left"></i>
+            <FaArrowLeft />
             <span>Volver a servicios</span>
           </Link>
           
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-4xl font-bold text-dark mb-2 flex items-center gap-3">
-                <i className="fas fa-shopping-cart text-primary"></i>
+                <FaShoppingCart className="text-primary" />
                 Mi Carrito de Compras
               </h1>
               <p className="text-gray-medium">
@@ -113,7 +115,7 @@ const CartPage: React.FC = () => {
                 }}
                 className="px-4 py-2 text-danger hover:bg-danger/10 rounded-lg transition-colors flex items-center gap-2"
               >
-                <i className="fas fa-trash"></i>
+                <FaTrash />
                 Vaciar carrito
               </button>
             )}
@@ -122,14 +124,14 @@ const CartPage: React.FC = () => {
 
         {items.length === 0 ? (
           <div className="bg-white rounded-2xl shadow-lg p-12 text-center">
-            <i className="fas fa-shopping-cart text-8xl text-gray-300 mb-6"></i>
+            <FaShoppingCart className="text-8xl text-gray-300 mb-6" />
             <h2 className="text-2xl font-bold text-gray-dark mb-4">Tu carrito está vacío</h2>
             <p className="text-gray-medium mb-8">Explora nuestros servicios profesionales y comienza a construir tu proyecto</p>
             <Link
               to="/"
               className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all"
             >
-              <i className="fas fa-search"></i>
+              <FaSearch />
               Explorar Servicios
             </Link>
           </div>
@@ -139,7 +141,7 @@ const CartPage: React.FC = () => {
             <div className="lg:col-span-2 space-y-4">
               <div className="bg-white rounded-xl shadow-md p-6">
                 <h2 className="text-2xl font-bold text-dark mb-6 flex items-center gap-2">
-                  <i className="fas fa-list text-primary"></i>
+                  <FaList className="text-primary" />
                   Servicios Seleccionados
                 </h2>
                 
@@ -152,7 +154,7 @@ const CartPage: React.FC = () => {
                       {/* Header de la card */}
                       <div className="flex items-center gap-4 p-4 border-b border-gray-100">
                         <div className="w-12 h-12 bg-gradient-to-br from-primary to-secondary rounded-xl flex items-center justify-center flex-shrink-0 shadow-md">
-                          <i className={`fas ${item.product.icon || 'fa-code'} text-xl text-white`}></i>
+                          { (() => { const ic = (item.product as any).icon; const I = faIconMap[ic] ?? faIconMap['fa-code']; return <I className="text-xl text-white" />; })() }
                         </div>
                         
                         <div className="flex-1 min-w-0">
@@ -175,7 +177,7 @@ const CartPage: React.FC = () => {
                           }}
                           title="Eliminar del carrito"
                         >
-                          <i className="fas fa-trash text-sm"></i>
+                          <FaTrash className="text-sm" />
                         </button>
                       </div>
                       
@@ -188,7 +190,7 @@ const CartPage: React.FC = () => {
                             <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
                               {item.product.features.slice(0, 8).map((feature, idx) => (
                                 <div key={idx} className="flex items-start gap-2 text-sm text-gray-600">
-                                  <i className="fas fa-check text-emerald-500 mt-0.5 text-xs flex-shrink-0"></i>
+                                  <FaCheck className="text-emerald-500 mt-0.5 text-xs flex-shrink-0" />
                                   <span className="line-clamp-1">{feature}</span>
                                 </div>
                               ))}
@@ -199,7 +201,7 @@ const CartPage: React.FC = () => {
                         {/* Delivery time */}
                         {item.product.deliveryTime && (
                           <div className="inline-flex items-center gap-1.5 text-xs text-gray-500 bg-gray-50 px-3 py-1.5 rounded-full mb-4">
-                            <i className="fas fa-clock text-primary"></i>
+                            <FaClock className="text-primary" />
                             <span>Tiempo de entrega: {item.product.deliveryTime}</span>
                           </div>
                         )}
@@ -208,7 +210,7 @@ const CartPage: React.FC = () => {
                         {item.customizations && (
                           <div className="bg-blue-50 border border-blue-100 rounded-lg p-2.5 mb-4">
                             <p className="text-xs text-blue-700">
-                              <i className="fas fa-edit mr-1.5"></i>
+                              <FaEdit className="mr-1.5" />
                               <span className="font-medium">Personalización:</span> {item.customizations}
                             </p>
                           </div>
@@ -253,7 +255,7 @@ const CartPage: React.FC = () => {
             <div className="lg:col-span-1">
               <div className="bg-white rounded-xl shadow-md p-6 sticky top-4">
                 <h2 className="text-2xl font-bold text-dark mb-6 flex items-center gap-2">
-                  <i className="fas fa-receipt text-primary"></i>
+                  <FaReceipt className="text-primary" />
                   Resumen
                 </h2>
                 
@@ -261,7 +263,7 @@ const CartPage: React.FC = () => {
                 <div className="space-y-4 mb-6">
                   <div className="flex justify-between items-center pb-3 border-b border-gray-200">
                     <span className="text-gray-medium flex items-center gap-2">
-                      <i className="fas fa-shopping-bag"></i>
+                      <FaShoppingBag />
                       Total de productos
                     </span>
                     <span className="text-lg font-bold text-dark">
@@ -271,7 +273,7 @@ const CartPage: React.FC = () => {
                   
                   <div className="flex justify-between items-center pb-3 border-b border-gray-200">
                     <span className="text-gray-medium flex items-center gap-2">
-                      <i className="fas fa-tags"></i>
+                      <FaTags />
                       Servicios únicos
                     </span>
                     <span className="text-lg font-bold text-dark">{items.length}</span>
@@ -293,7 +295,7 @@ const CartPage: React.FC = () => {
                 {/* Campo de comentarios */}
                 <div className="mb-6">
                   <label className="flex items-center gap-2 text-sm font-semibold text-dark mb-2">
-                    <i className="fas fa-comment-alt text-primary"></i>
+                    <FaCommentAlt className="text-primary" />
                     Comentarios <span className="text-gray-medium font-normal">(Opcional)</span>
                   </label>
                   <textarea
@@ -322,7 +324,7 @@ const CartPage: React.FC = () => {
                     />
                     <div className="flex-1">
                       <div className="flex items-center gap-2 text-dark font-semibold mb-1">
-                        <i className="fas fa-file-invoice text-secondary"></i>
+                        <FaFileInvoice className="text-secondary" />
                         Solicitar cotización sin costo
                       </div>
                       <p className="text-xs text-gray-medium">
@@ -335,13 +337,13 @@ const CartPage: React.FC = () => {
                 {!isAuthenticated ? (
                   <div className="bg-primary/10 border border-primary/20 rounded-lg p-4 text-center">
                     <div className="flex flex-col items-center gap-4">
-                      <i className="fas fa-info-circle text-primary text-2xl"></i>
+                      <FaInfoCircle className="text-primary text-2xl" />
                       <p className="text-gray-dark">Inicia sesión para proceder con la compra</p>
                       <button 
                         className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all" 
                         onClick={openLogin}
                       >
-                        <i className="fas fa-sign-in-alt"></i>
+                        <FaSignInAlt />
                         Iniciar Sesión
                       </button>
                     </div>
@@ -359,17 +361,17 @@ const CartPage: React.FC = () => {
                     >
                       {isProcessing ? (
                         <>
-                          <i className="fas fa-spinner fa-spin"></i>
+                          <FaSpinner className="animate-spin" />
                           Procesando...
                         </>
                       ) : isQuoteMode ? (
                         <>
-                          <i className="fas fa-file-invoice"></i>
+                          <FaFileInvoice />
                           Solicitar Cotización
                         </>
                       ) : (
                         <>
-                          <i className="fas fa-credit-card"></i>
+                          <FaCreditCard />
                           Proceder al Pago - ${totalAmount.toLocaleString()} USD
                         </>
                       )}
@@ -377,15 +379,15 @@ const CartPage: React.FC = () => {
                     
                     {!isQuoteMode && (
                       <div className="flex gap-3 justify-center mb-4 opacity-70">
-                        <i className="fab fa-cc-visa text-3xl text-gray-dark"></i>
-                        <i className="fab fa-cc-mastercard text-3xl text-gray-dark"></i>
-                        <i className="fab fa-cc-paypal text-3xl text-gray-dark"></i>
-                        <i className="fab fa-cc-amex text-3xl text-gray-dark"></i>
+                        <FaCcVisa className="text-3xl text-gray-dark" />
+                        <FaCcMastercard className="text-3xl text-gray-dark" />
+                        <FaCcPaypal className="text-3xl text-gray-dark" />
+                        <FaCcAmex className="text-3xl text-gray-dark" />
                       </div>
                     )}
                     
                     <div className="flex items-center justify-center gap-2 text-sm text-gray-medium">
-                      <i className={`fas ${isQuoteMode ? 'fa-envelope' : 'fa-shield-alt'} ${isQuoteMode ? 'text-secondary' : 'text-success'}`}></i>
+                      {isQuoteMode ? <FaEnvelope className="text-secondary" /> : <FaShieldAlt className="text-success" />}
                       <span>{isQuoteMode ? 'Cotización por email' : 'Pago seguro - Simulación'}</span>
                     </div>
                   </div>

--- a/src/presentation/utils/faIconMap.tsx
+++ b/src/presentation/utils/faIconMap.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react';
+import type { IconBaseProps } from 'react-icons';
+import {
+  FaCode, FaMobileAlt, FaInfinity, FaCloud, FaLightbulb, FaGraduationCap,
+  FaPlug, FaShoppingCart, FaServer, FaCodeBranch, FaShieldAlt, FaDatabase,
+  FaChalkboardTeacher, FaStore, FaProjectDiagram, FaUniversity, FaCity,
+  FaCertificate,
+} from 'react-icons/fa';
+
+export type FaIconComponent = FC<IconBaseProps>;
+
+export const faIconMap: Record<string, FaIconComponent> = {
+  'fa-code':               FaCode,
+  'fa-mobile-alt':         FaMobileAlt,
+  'fa-infinity':           FaInfinity,
+  'fa-cloud':              FaCloud,
+  'fa-lightbulb':          FaLightbulb,
+  'fa-graduation-cap':     FaGraduationCap,
+  'fa-plug':               FaPlug,
+  'fa-shopping-cart':      FaShoppingCart,
+  'fa-server':             FaServer,
+  'fa-code-branch':        FaCodeBranch,
+  'fa-shield-alt':         FaShieldAlt,
+  'fa-database':           FaDatabase,
+  'fa-chalkboard-teacher': FaChalkboardTeacher,
+  'fa-store':              FaStore,
+  'fa-project-diagram':    FaProjectDiagram,
+  'fa-university':         FaUniversity,
+  'fa-city':               FaCity,
+  'fa-certificate':        FaCertificate,
+};


### PR DESCRIPTION
## Summary

- Elimina el `<link>` de Font Awesome CDN (`cdnjs.cloudflare.com`) — ya no hay dependencia externa render-blocking para íconos
- Crea `src/presentation/utils/faIconMap.tsx` — mapa compartido para íconos dinámicos (strings desde `services.ts`, `projects.ts`, `experiences.ts`)
- Migra **15 componentes + CartPage**: todos los `<i className="fas/fab fa-*">` → componentes de `react-icons/fa`
- `fa-spin` → `animate-spin` (Tailwind)
- Íconos dinámicos desde datos → lookup con `faIconMap`
- Íconos condicionales (`isQuoteMode`, `service.available`) → ternario JSX
- Limpia `animatedElements` huérfano en `AnimationManager`

## Scope

18 archivos cambiados · 187 inserciones · 133 eliminaciones

## Test plan

- [x] Verificar íconos visibles en Hero (redes sociales, CTA)
- [x] Verificar íconos en Navigation (usuario, carrito, chevron)
- [x] Verificar íconos de categorías en Services (th, chevrons, filtros)
- [x] Verificar íconos en cards de servicios (dinámicos por categoría)
- [x] Verificar íconos en Portfolio y Experience
- [x] Verificar íconos en formulario de Contact (spinner, checkmark)
- [x] Verificar modales (Login, Register, Profile, Cart, Orders)
- [x] DevTools → Network: confirmar que **no** aparece ninguna request a `cdnjs.cloudflare.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)