### PR TITLE
feat: lazy load modals and CartPage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,17 @@
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { CartProvider } from './application/context/CartContext';
 import { AuthProvider } from './application/context/AuthContext';
 import { ModalProvider } from './application/context/ModalContext';
 import HomePage from './presentation/pages/HomePage.tsx';
-import CartPage from './presentation/pages/CartPage.tsx';
 import { AnimationManager } from './infrastructure/services/AnimationManager';
+
+const CartPage = lazy(() => import('./presentation/pages/CartPage.tsx'));
 
 function App() {
   useEffect(() => {
-    // Inicializar animaciones cuando el DOM está listo
     const animationManager = new AnimationManager();
-    
     return () => {
-      // Cleanup si es necesario
       animationManager.resetAnimations();
     };
   }, []);
@@ -25,7 +23,18 @@ function App() {
           <ModalProvider>
             <Routes>
               <Route path="/" element={<HomePage />} />
-              <Route path="/carrito" element={<CartPage />} />
+              <Route
+                path="/carrito"
+                element={
+                  <Suspense fallback={
+                    <div className="min-h-screen flex items-center justify-center">
+                      <div className="w-10 h-10 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+                    </div>
+                  }>
+                    <CartPage />
+                  </Suspense>
+                }
+              />
             </Routes>
           </ModalProvider>
         </CartProvider>

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Navigation from '../components/Navigation.tsx';
 import Hero from '../components/Hero.tsx';
@@ -8,11 +8,12 @@ import Portfolio from '../components/Portfolio.tsx';
 import Experience from '../components/Experience.tsx';
 import Contact from '../components/Contact.tsx';
 import Footer from '../components/Footer.tsx';
-import LoginModal from '../components/LoginModal.tsx';
-import RegisterModal from '../components/RegisterModal.tsx';
-import ProfileModal from '../components/ProfileModal.tsx';
-import OrdersModal from '../components/OrdersModal.tsx';
 import { useModal } from '../../application/context/ModalContext';
+
+const LoginModal = lazy(() => import('../components/LoginModal.tsx'));
+const RegisterModal = lazy(() => import('../components/RegisterModal.tsx'));
+const ProfileModal = lazy(() => import('../components/ProfileModal.tsx'));
+const OrdersModal = lazy(() => import('../components/OrdersModal.tsx'));
 
 const HomePage: React.FC = () => {
   const location = useLocation();
@@ -73,11 +74,19 @@ const HomePage: React.FC = () => {
       <Contact />
       <Footer />
       
-      {/* Modals */}
-      <LoginModal isOpen={isLoginOpen} onClose={closeLogin} onShowRegister={switchToRegister} />
-      <RegisterModal isOpen={isRegisterOpen} onClose={closeRegister} onShowLogin={switchToLogin} />
-      <ProfileModal isOpen={isProfileOpen} onClose={closeProfile} />
-      <OrdersModal isOpen={isOrdersOpen} onClose={closeOrders} />
+      {/* Modals — lazy loaded, chunks download only when first opened */}
+      <Suspense fallback={null}>
+        {isLoginOpen && <LoginModal isOpen={isLoginOpen} onClose={closeLogin} onShowRegister={switchToRegister} />}
+      </Suspense>
+      <Suspense fallback={null}>
+        {isRegisterOpen && <RegisterModal isOpen={isRegisterOpen} onClose={closeRegister} onShowLogin={switchToLogin} />}
+      </Suspense>
+      <Suspense fallback={null}>
+        {isProfileOpen && <ProfileModal isOpen={isProfileOpen} onClose={closeProfile} />}
+      </Suspense>
+      <Suspense fallback={null}>
+        {isOrdersOpen && <OrdersModal isOpen={isOrdersOpen} onClose={closeOrders} />}
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- `CartPage` moved to `React.lazy` + `Suspense` — only downloads on `/carrito` navigation
- `LoginModal`, `RegisterModal`, `ProfileModal`, and `OrdersModal` wrapped with `React.lazy` + `Suspense fallback={null}` — chunks load on-demand when each modal is first opened
- Each modal conditionally rendered (`{isOpen && <Modal>}`) so the chunk never fetches until triggered

## Bundle impact
| Chunk | Gzip |
|---|---|
| `OrdersModal` | 1.08 kB |
| `LoginModal` | 1.49 kB |
| `ProfileModal` | 1.62 kB |
| `RegisterModal` | 2.20 kB |
| `CartPage` | 3.58 kB |
| **Removed from main bundle** | **~33 kB** |

## Test plan
- [x] Home page loads normally, all sections visible
- [x] Click login → LoginModal appears (first open loads chunk, instant on repeat)
- [x] Click register → RegisterModal appears
- [x] Navigate to `/carrito` → CartPage renders (spinner during load)
- [x] No TypeScript or build errors (`npm run build` passes clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)