### PR TITLE
fix: connect t() to all hardcoded Spanish strings

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -212,7 +212,8 @@
     "title": "My Orders",
     "empty": "You don't have orders yet",
     "emptyDescription": "When you make a purchase, your orders will appear here",
-    "explore": "Explore Services"
+    "explore": "Explore Services",
+    "viewDetails": "View Details"
   },
   "serviceDetail": {
     "description": "Detailed Description",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -212,7 +212,8 @@
     "title": "Mis Pedidos",
     "empty": "Aún no tienes pedidos",
     "emptyDescription": "Cuando realices una compra, tus pedidos aparecerán aquí",
-    "explore": "Explorar Servicios"
+    "explore": "Explorar Servicios",
+    "viewDetails": "Ver Detalles"
   },
   "serviceDetail": {
     "description": "Descripción Detallada",

--- a/src/presentation/components/OrdersModal.tsx
+++ b/src/presentation/components/OrdersModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../application/hooks/useAuth';
 import { FaShoppingBag } from 'react-icons/fa';
 
@@ -21,6 +22,7 @@ interface OrdersModalProps {
 }
 
 const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
   const { user } = useAuth();
 
   // TODO: Fetch orders from backend
@@ -32,7 +34,7 @@ const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 bg-dark/80 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={onClose}>
       <div className="bg-white rounded-2xl shadow-2xl max-w-3xl w-full max-h-[90vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between p-6 border-b border-gray-lighter">
-          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><FaShoppingBag className="text-primary" /> Mis Órdenes</h2>
+          <h2 className="text-2xl font-bold text-dark flex items-center gap-3"><FaShoppingBag className="text-primary" /> {t('orders.title')}</h2>
           <button className="w-10 h-10 bg-gray-lighter hover:bg-gray-light rounded-full flex items-center justify-center text-gray-dark hover:text-dark transition-colors text-2xl" onClick={onClose}>&times;</button>
         </div>
         
@@ -40,10 +42,10 @@ const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
           {orders.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <FaShoppingBag className="text-8xl text-gray-light mb-6" />
-              <h3 className="text-2xl font-bold text-dark mb-2">No tienes órdenes aún</h3>
-              <p className="text-gray-medium mb-6">Cuando realices tu primera compra, aparecerá aquí.</p>
+              <h3 className="text-2xl font-bold text-dark mb-2">{t('orders.empty')}</h3>
+              <p className="text-gray-medium mb-6">{t('orders.emptyDescription')}</p>
               <button className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all" onClick={onClose}>
-                Explorar Servicios
+                {t('orders.explore')}
               </button>
             </div>
           ) : (
@@ -70,7 +72,7 @@ const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
                   <div className="flex justify-between items-center pt-4 border-t border-gray-light">
                     <strong className="text-lg text-dark">Total: ${order.total.toLocaleString()} USD</strong>
                     <button className="inline-flex items-center gap-2 px-4 py-2 bg-white text-primary font-semibold rounded-lg border-2 border-primary hover:bg-primary hover:text-white transition-all text-sm">
-                      Ver Detalles
+                      {t('orders.viewDetails')}
                     </button>
                   </div>
                 </div>

--- a/src/presentation/components/Portfolio.tsx
+++ b/src/presentation/components/Portfolio.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { GetProjectsUseCase } from '../../domain/use-cases/GetProjectsUseCase';
 import { ProjectRepositoryImpl } from '../../infrastructure/repositories/ProjectRepositoryImpl';
 import { Project } from '../../domain/entities/Project';
@@ -7,6 +8,7 @@ import { FaExternalLinkAlt } from 'react-icons/fa';
 import { faIconMap } from '../utils/faIconMap';
 
 const Portfolio: React.FC = () => {
+  const { t } = useTranslation();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -31,7 +33,7 @@ const Portfolio: React.FC = () => {
     return (
       <section className="py-24 bg-white" id="portafolio">
         <div className="max-w-7xl mx-auto px-8 text-center">
-          <p className="text-gray-medium">Cargando proyectos...</p>
+          <p className="text-gray-medium">{t('common.loading')}</p>
         </div>
       </section>
     );
@@ -41,8 +43,8 @@ const Portfolio: React.FC = () => {
     <section className="py-24 bg-white" id="portafolio">
       <div className="max-w-7xl mx-auto px-8">
         <div className="text-center mb-16">
-          <h2 className="text-4xl font-bold text-dark mb-4">Proyectos Destacados</h2>
-          <p className="text-lg text-gray-medium max-w-2xl mx-auto">Algunos de los proyectos más relevantes en mi carrera</p>
+          <h2 className="text-4xl font-bold text-dark mb-4">{t('portfolio.title')}</h2>
+          <p className="text-lg text-gray-medium max-w-2xl mx-auto">{t('portfolio.subtitle')}</p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {projects.map((project) => (
@@ -85,7 +87,7 @@ const Portfolio: React.FC = () => {
                       target="_blank"
                       rel="noopener noreferrer"
                       className="ml-2 text-primary hover:text-dark transition-colors"
-                      title="Ver proyecto"
+                      title={t('portfolio.viewProject')}
                     >
                       <FaExternalLinkAlt className="text-sm" />
                     </a>

--- a/src/presentation/components/ServiceDetailModal.tsx
+++ b/src/presentation/components/ServiceDetailModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Service } from '../../domain/entities/Service';
 import { faIconMap } from '../utils/faIconMap';
 
@@ -17,6 +18,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
   service,
   onAddToCart
 }) => {
+  const { t } = useTranslation();
   if (!isOpen || !service) return null;
 
   const handleAddToCart = () => {
@@ -69,7 +71,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                   </span>
                   {service.featured && (
                     <span className="px-2.5 py-1 bg-accent/90 backdrop-blur-sm text-white text-xs font-bold uppercase tracking-wider rounded-full flex items-center gap-1">
-                      <FaStar className="text-[10px]" /> Popular
+                      <FaStar className="text-[10px]" /> {t('services.popular')}
                     </span>
                   )}
                 </div>
@@ -97,7 +99,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               <div>
                 <h3 className="text-xl font-bold text-dark mb-3 flex items-center gap-2">
                   <FaInfoCircle className="text-primary" />
-                  Descripción Detallada
+                  {t('serviceDetail.description')}
                 </h3>
                 <p className="text-gray-dark leading-relaxed">{service.description}</p>
               </div>
@@ -106,7 +108,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               <div>
                 <h3 className="text-xl font-bold text-dark mb-4 flex items-center gap-2">
                   <FaCheckDouble className="text-secondary" />
-                  Características Incluidas
+                  {t('serviceDetail.features')}
                 </h3>
                 <ul className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {service.features.map((feature, index) => (
@@ -125,7 +127,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
               <div>
                 <h3 className="text-xl font-bold text-dark mb-4 flex items-center gap-2">
                   <FaLayerGroup className="text-accent" />
-                  Tecnologías Utilizadas
+                  {t('serviceDetail.technologies')}
                 </h3>
                 <div className="flex flex-wrap gap-2">
                   {service.technologies.map((tech, index) => (
@@ -156,7 +158,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                 {service.deliveryTime && (
                   <div className="flex items-center justify-center gap-2 text-gray-dark text-sm bg-white p-3 rounded-lg border border-gray-200 mb-4">
                     <FaClock className="text-primary" />
-                    <span className="font-medium">Entrega: {service.deliveryTime}</span>
+                    <span className="font-medium">{t('serviceDetail.delivery')} {service.deliveryTime}</span>
                   </div>
                 )}
 
@@ -167,7 +169,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                       className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-gradient-primary text-white font-semibold rounded-xl shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-300"
                     >
                       <FaShoppingCart />
-                      Agregar al Carrito
+                      {t('serviceDetail.addToCart')}
                     </button>
                   )}
 
@@ -176,7 +178,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                     className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 bg-white text-primary font-semibold rounded-xl border-2 border-primary hover:bg-primary hover:text-white hover:scale-105 transition-all duration-300"
                   >
                     <FaPaperPlane />
-                    Contactar Ahora
+                    {t('serviceDetail.contactNow')}
                   </button>
                 </div>
               </div>
@@ -186,7 +188,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
                 <div className="flex items-center gap-2 justify-center">
                   {service.available ? <FaCheckCircle className="text-success" /> : <FaTimesCircle className="text-gray-500" />}
                   <span className={`font-semibold ${service.available ? 'text-success' : 'text-gray-500'}`}>
-                    {service.available ? 'Disponible Ahora' : 'No Disponible'}
+                    {service.available ? t('serviceDetail.available') : t('serviceDetail.unavailable')}
                   </span>
                 </div>
               </div>

--- a/src/presentation/pages/CartPage.tsx
+++ b/src/presentation/pages/CartPage.tsx
@@ -1,6 +1,7 @@
 import { FaArrowLeft, FaShoppingCart, FaTrash, FaSearch, FaList, FaClock, FaEdit, FaReceipt, FaShoppingBag, FaTags, FaCommentAlt, FaFileInvoice, FaInfoCircle, FaSignInAlt, FaSpinner, FaCreditCard, FaCheck, FaCcVisa, FaCcMastercard, FaCcPaypal, FaCcAmex, FaEnvelope, FaShieldAlt } from 'react-icons/fa';
 import { faIconMap } from '../utils/faIconMap';
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useCart } from '../../application/hooks/useCart';
 import { useAuth } from '../../application/hooks/useAuth';
 import { useModal } from '../../application/context/ModalContext';
@@ -10,6 +11,7 @@ import LoginModal from '../components/LoginModal';
 import RegisterModal from '../components/RegisterModal';
 
 const CartPage: React.FC = () => {
+  const { t } = useTranslation();
   const { items, totalAmount, updateQuantity, removeFromCart, clearCart } = useCart();
   const { isAuthenticated, user } = useAuth();
   const { 
@@ -85,19 +87,19 @@ const CartPage: React.FC = () => {
             className="inline-flex items-center gap-2 text-gray-600 hover:text-primary transition-colors mb-4"
           >
             <FaArrowLeft />
-            <span>Volver a servicios</span>
+            <span>{t('cart.back')}</span>
           </Link>
           
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-4xl font-bold text-dark mb-2 flex items-center gap-3">
                 <FaShoppingCart className="text-primary" />
-                Mi Carrito de Compras
+                {t('cart.title')}
               </h1>
               <p className="text-gray-medium">
                 {items.length === 0 
-                  ? 'Tu carrito está vacío' 
-                  : `${items.length} ${items.length === 1 ? 'servicio' : 'servicios'} en tu carrito`
+                  ? t('cart.empty')
+                  : `${items.length} ${items.length === 1 ? t('cart.serviceInCart') : t('cart.servicesInCart')}`
                 }
               </p>
             </div>
@@ -105,10 +107,10 @@ const CartPage: React.FC = () => {
             {items.length > 0 && (
               <button
                 onClick={() => {
-                  if (confirm('¿Estás seguro de que deseas vaciar el carrito?')) {
+                  if (confirm(t('cart.confirmClear'))) {
                     clearCart();
                     notificationManager.show({
-                      message: 'Carrito vaciado',
+                      message: t('cart.cleared'),
                       type: 'success'
                     });
                   }
@@ -116,7 +118,7 @@ const CartPage: React.FC = () => {
                 className="px-4 py-2 text-danger hover:bg-danger/10 rounded-lg transition-colors flex items-center gap-2"
               >
                 <FaTrash />
-                Vaciar carrito
+                {t('cart.clearCart')}
               </button>
             )}
           </div>
@@ -125,14 +127,14 @@ const CartPage: React.FC = () => {
         {items.length === 0 ? (
           <div className="bg-white rounded-2xl shadow-lg p-12 text-center">
             <FaShoppingCart className="text-8xl text-gray-300 mb-6" />
-            <h2 className="text-2xl font-bold text-gray-dark mb-4">Tu carrito está vacío</h2>
-            <p className="text-gray-medium mb-8">Explora nuestros servicios profesionales y comienza a construir tu proyecto</p>
+            <h2 className="text-2xl font-bold text-gray-dark mb-4">{t('cart.empty')}</h2>
+            <p className="text-gray-medium mb-8">{t('cart.emptyDescription')}</p>
             <Link
               to="/"
               className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all"
             >
               <FaSearch />
-              Explorar Servicios
+              {t('cart.explore')}
             </Link>
           </div>
         ) : (
@@ -142,7 +144,7 @@ const CartPage: React.FC = () => {
               <div className="bg-white rounded-xl shadow-md p-6">
                 <h2 className="text-2xl font-bold text-dark mb-6 flex items-center gap-2">
                   <FaList className="text-primary" />
-                  Servicios Seleccionados
+                  {t('cart.selectedServices')}
                 </h2>
                 
                 <div className="space-y-4">
@@ -171,7 +173,7 @@ const CartPage: React.FC = () => {
                           onClick={() => {
                             removeFromCart(item.product.id);
                             notificationManager.show({
-                              message: `${item.product.title} eliminado del carrito`,
+                              message: `${item.product.title} ${t('cart.removed')}`,
                               type: 'success'
                             });
                           }}
@@ -186,7 +188,7 @@ const CartPage: React.FC = () => {
                         {/* Features en grid compacto */}
                         {item.product.features && item.product.features.length > 0 && (
                           <div className="mb-4">
-                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Características incluidas:</p>
+                            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">{t('cart.featuresIncluded')}</p>
                             <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
                               {item.product.features.slice(0, 8).map((feature, idx) => (
                                 <div key={idx} className="flex items-start gap-2 text-sm text-gray-600">
@@ -202,7 +204,7 @@ const CartPage: React.FC = () => {
                         {item.product.deliveryTime && (
                           <div className="inline-flex items-center gap-1.5 text-xs text-gray-500 bg-gray-50 px-3 py-1.5 rounded-full mb-4">
                             <FaClock className="text-primary" />
-                            <span>Tiempo de entrega: {item.product.deliveryTime}</span>
+                            <span>{t('cart.deliveryTime')} {item.product.deliveryTime}</span>
                           </div>
                         )}
                         
@@ -211,7 +213,7 @@ const CartPage: React.FC = () => {
                           <div className="bg-blue-50 border border-blue-100 rounded-lg p-2.5 mb-4">
                             <p className="text-xs text-blue-700">
                               <FaEdit className="mr-1.5" />
-                              <span className="font-medium">Personalización:</span> {item.customizations}
+                              <span className="font-medium">{t('cart.customization')}</span> {item.customizations}
                             </p>
                           </div>
                         )}
@@ -220,7 +222,7 @@ const CartPage: React.FC = () => {
                       {/* Footer con cantidad y precio */}
                       <div className="flex items-center justify-between px-4 py-3 bg-gray-50 border-t border-gray-100">
                         <div className="flex items-center gap-2">
-                          <span className="text-xs font-medium text-gray-500">Cantidad:</span>
+                          <span className="text-xs font-medium text-gray-500">{t('cart.quantity')}</span>
                           <div className="flex items-center bg-white rounded-lg border border-gray-200 shadow-sm">
                             <button 
                               className="w-8 h-8 hover:bg-gray-100 transition-colors text-gray-600 hover:text-gray-900 font-semibold rounded-l-lg text-sm"
@@ -239,7 +241,7 @@ const CartPage: React.FC = () => {
                         </div>
                         
                         <div className="text-right">
-                          <div className="text-xs text-gray-400">Precio unitario</div>
+                          <div className="text-xs text-gray-400">{t('cart.unitPrice')}</div>
                           <div className="text-xl font-bold text-gray-900">
                             ${item.product.price.amount.toLocaleString()} <span className="text-sm font-normal text-gray-500">{item.product.price.currency}</span>
                           </div>
@@ -256,7 +258,7 @@ const CartPage: React.FC = () => {
               <div className="bg-white rounded-xl shadow-md p-6 sticky top-4">
                 <h2 className="text-2xl font-bold text-dark mb-6 flex items-center gap-2">
                   <FaReceipt className="text-primary" />
-                  Resumen
+                  {t('cart.summary')}
                 </h2>
                 
                 {/* Resumen de la orden */}
@@ -264,7 +266,7 @@ const CartPage: React.FC = () => {
                   <div className="flex justify-between items-center pb-3 border-b border-gray-200">
                     <span className="text-gray-medium flex items-center gap-2">
                       <FaShoppingBag />
-                      Total de productos
+                      {t('cart.totalProducts')}
                     </span>
                     <span className="text-lg font-bold text-dark">
                       {items.reduce((sum, item) => sum + item.quantity, 0)}
@@ -274,19 +276,19 @@ const CartPage: React.FC = () => {
                   <div className="flex justify-between items-center pb-3 border-b border-gray-200">
                     <span className="text-gray-medium flex items-center gap-2">
                       <FaTags />
-                      Servicios únicos
+                      {t('cart.uniqueServices')}
                     </span>
                     <span className="text-lg font-bold text-dark">{items.length}</span>
                   </div>
                   
                   <div className="flex justify-between items-center pt-2">
-                    <span className="text-lg font-semibold text-dark">Total:</span>
+                    <span className="text-lg font-semibold text-dark">{t('cart.total')}</span>
                     <div className="text-right">
                       <div className="text-3xl font-bold bg-gradient-primary bg-clip-text text-transparent">
                         ${isQuoteMode ? 0 : totalAmount.toLocaleString()}
                       </div>
                       <div className="text-xs text-gray-medium">
-                        {isQuoteMode ? 'Cotización' : 'USD'}
+                        {isQuoteMode ? t('cart.quote') : 'USD'}
                       </div>
                     </div>
                   </div>
@@ -296,12 +298,12 @@ const CartPage: React.FC = () => {
                 <div className="mb-6">
                   <label className="flex items-center gap-2 text-sm font-semibold text-dark mb-2">
                     <FaCommentAlt className="text-primary" />
-                    Comentarios <span className="text-gray-medium font-normal">(Opcional)</span>
+                    {t('cart.comments')} <span className="text-gray-medium font-normal">{t('cart.commentsOptional')}</span>
                   </label>
                   <textarea
                     value={comments}
                     onChange={(e) => setComments(e.target.value)}
-                    placeholder="Requisitos especiales, preferencias de tecnología, plazos específicos..."
+                    placeholder={t('cart.commentsPlaceholder')}
                     className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all resize-none text-sm"
                     rows={4}
                     maxLength={500}
@@ -325,10 +327,10 @@ const CartPage: React.FC = () => {
                     <div className="flex-1">
                       <div className="flex items-center gap-2 text-dark font-semibold mb-1">
                         <FaFileInvoice className="text-secondary" />
-                        Solicitar cotización sin costo
+                        {t('cart.quoteMode')}
                       </div>
                       <p className="text-xs text-gray-medium">
-                        Te contactaremos con precios personalizados y detalles del proyecto.
+                        {t('cart.quoteModeDescription')}
                       </p>
                     </div>
                   </label>
@@ -338,13 +340,13 @@ const CartPage: React.FC = () => {
                   <div className="bg-primary/10 border border-primary/20 rounded-lg p-4 text-center">
                     <div className="flex flex-col items-center gap-4">
                       <FaInfoCircle className="text-primary text-2xl" />
-                      <p className="text-gray-dark">Inicia sesión para proceder con la compra</p>
-                      <button 
-                        className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all" 
+                      <p className="text-gray-dark">{t('cart.loginRequired')}</p>
+                      <button
+                        className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-primary text-white font-semibold rounded-lg shadow-lg hover:-translate-y-0.5 hover:shadow-xl transition-all"
                         onClick={openLogin}
                       >
                         <FaSignInAlt />
-                        Iniciar Sesión
+                        {t('nav.login')}
                       </button>
                     </div>
                   </div>
@@ -362,17 +364,17 @@ const CartPage: React.FC = () => {
                       {isProcessing ? (
                         <>
                           <FaSpinner className="animate-spin" />
-                          Procesando...
+                          {t('cart.processing')}
                         </>
                       ) : isQuoteMode ? (
                         <>
                           <FaFileInvoice />
-                          Solicitar Cotización
+                          {t('cart.requestQuote')}
                         </>
                       ) : (
                         <>
                           <FaCreditCard />
-                          Proceder al Pago - ${totalAmount.toLocaleString()} USD
+                          {t('cart.proceedPayment')} - ${totalAmount.toLocaleString()} USD
                         </>
                       )}
                     </button>
@@ -388,7 +390,7 @@ const CartPage: React.FC = () => {
                     
                     <div className="flex items-center justify-center gap-2 text-sm text-gray-medium">
                       {isQuoteMode ? <FaEnvelope className="text-secondary" /> : <FaShieldAlt className="text-success" />}
-                      <span>{isQuoteMode ? 'Cotización por email' : 'Pago seguro - Simulación'}</span>
+                      <span>{isQuoteMode ? t('cart.quoteByEmail') : t('cart.securePayment')}</span>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
Portfolio, ServiceDetailModal, OrdersModal, and CartPage had ~40 hardcoded Spanish strings despite all translation keys already existing in `en.json`/`es.json`. Switching the language to English would still show Spanish text in these components.

- **Portfolio.tsx** — `"Proyectos Destacados"`, `"Algunos de los proyectos..."`, `"Cargando proyectos..."`, `"Ver proyecto"` title
- **ServiceDetailModal.tsx** — `"Popular"`, `"Descripción Detallada"`, `"Características Incluidas"`, `"Tecnologías Utilizadas"`, `"Entrega:"`, `"Agregar al Carrito"`, `"Contactar Ahora"`, `"Disponible Ahora"`, `"No Disponible"`
- **OrdersModal.tsx** — `"Mis Órdenes"`, `"No tienes órdenes aún"`, `"Cuando realices tu primera compra..."`, `"Explorar Servicios"`, `"Ver Detalles"`
- **CartPage.tsx** — ~25 strings: title, empty state, cart actions, item details, checkout labels, payment/quote modes
- **en.json + es.json** — added missing `orders.viewDetails` key

No new translation keys needed (except `orders.viewDetails`) — all keys were already defined.

## Test plan
- [x] Switch language to English → Portfolio, ServiceDetailModal, OrdersModal, CartPage show English text
- [x] Switch back to Spanish → all strings return to Spanish
- [x] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)