### PR TITLE
feat: ErrorBoundary for lazy-loaded chunks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,29 @@
-import { lazy, Suspense, useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import React, { lazy, Suspense, useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { CartProvider } from './application/context/CartContext';
 import { AuthProvider } from './application/context/AuthContext';
 import { ModalProvider } from './application/context/ModalContext';
 import HomePage from './presentation/pages/HomePage.tsx';
 import { AnimationManager } from './infrastructure/services/AnimationManager';
+import ErrorBoundary from './presentation/components/ErrorBoundary';
 
 const CartPage = lazy(() => import('./presentation/pages/CartPage.tsx'));
+
+const CartLoadError: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 p-8 text-center">
+      <p className="text-xl font-semibold text-dark">{t('common.loadError')}</p>
+      <Link
+        to="/"
+        className="px-6 py-3 bg-primary text-white font-semibold rounded-lg hover:-translate-y-0.5 transition-all"
+      >
+        {t('nav.home')}
+      </Link>
+    </div>
+  );
+};
 
 function App() {
   useEffect(() => {
@@ -26,13 +43,15 @@ function App() {
               <Route
                 path="/carrito"
                 element={
-                  <Suspense fallback={
-                    <div className="min-h-screen flex items-center justify-center">
-                      <div className="w-10 h-10 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
-                    </div>
-                  }>
-                    <CartPage />
-                  </Suspense>
+                  <ErrorBoundary fallback={<CartLoadError />}>
+                    <Suspense fallback={
+                      <div className="min-h-screen flex items-center justify-center">
+                        <div className="w-10 h-10 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+                      </div>
+                    }>
+                      <CartPage />
+                    </Suspense>
+                  </ErrorBoundary>
                 }
               />
             </Routes>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -234,6 +234,7 @@
   },
   "common": {
     "loading": "Loading...",
+    "loadError": "Failed to load. Try refreshing the page.",
     "error": "Error",
     "success": "Success",
     "cancel": "Cancel",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -234,6 +234,7 @@
   },
   "common": {
     "loading": "Cargando...",
+    "loadError": "Error al cargar. Intenta recargar la página.",
     "error": "Error",
     "success": "Éxito",
     "cancel": "Cancelar",

--- a/src/presentation/components/ErrorBoundary.tsx
+++ b/src/presentation/components/ErrorBoundary.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { lazy, Suspense, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
+import ErrorBoundary from '../components/ErrorBoundary';
 import Navigation from '../components/Navigation.tsx';
 import Hero from '../components/Hero.tsx';
 import Services from '../components/Services.tsx';
@@ -74,19 +75,27 @@ const HomePage: React.FC = () => {
       <Contact />
       <Footer />
       
-      {/* Modals — lazy loaded, chunks download only when first opened */}
-      <Suspense fallback={null}>
-        {isLoginOpen && <LoginModal isOpen={isLoginOpen} onClose={closeLogin} onShowRegister={switchToRegister} />}
-      </Suspense>
-      <Suspense fallback={null}>
-        {isRegisterOpen && <RegisterModal isOpen={isRegisterOpen} onClose={closeRegister} onShowLogin={switchToLogin} />}
-      </Suspense>
-      <Suspense fallback={null}>
-        {isProfileOpen && <ProfileModal isOpen={isProfileOpen} onClose={closeProfile} />}
-      </Suspense>
-      <Suspense fallback={null}>
-        {isOrdersOpen && <OrdersModal isOpen={isOrdersOpen} onClose={closeOrders} />}
-      </Suspense>
+      {/* Modals — lazy loaded; ErrorBoundary silently drops the modal if the chunk fails */}
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          {isLoginOpen && <LoginModal isOpen={isLoginOpen} onClose={closeLogin} onShowRegister={switchToRegister} />}
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          {isRegisterOpen && <RegisterModal isOpen={isRegisterOpen} onClose={closeRegister} onShowLogin={switchToLogin} />}
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          {isProfileOpen && <ProfileModal isOpen={isProfileOpen} onClose={closeProfile} />}
+        </Suspense>
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          {isOrdersOpen && <OrdersModal isOpen={isOrdersOpen} onClose={closeOrders} />}
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };


### PR DESCRIPTION
## Problem
PR #27 added `React.lazy()` for CartPage and 4 modals. Without error boundaries, a failed dynamic import (network blip, CDN timeout, stale chunk hash after deploy) throws an uncaught error that unmounts the entire React tree — blank white screen with no recovery path.

## Solution
New `ErrorBoundary` class component (React's required API for this — hooks can't catch render errors).

### CartPage route (`App.tsx`)
```
<ErrorBoundary fallback={<CartLoadError />}>
  <Suspense fallback={<spinner>}>
    <CartPage />
  </Suspense>
</ErrorBoundary>
```
`CartLoadError` is a functional component (so it can use `useTranslation` + `Link`) that shows `t('common.loadError')` and a link back to home — user can recover without a full page refresh.

### Modal Suspenses (`HomePage.tsx`)
```
<ErrorBoundary>   {/* fallback=null */}
  <Suspense fallback={null}>
    {isLoginOpen && <LoginModal ... />}
  </Suspense>
</ErrorBoundary>
```
Silent failure: if a modal chunk errors, the overlay simply doesn't appear. The page behind stays intact. Better than crashing the whole app.

## Files
| File | Change |
|---|---|
| `ErrorBoundary.tsx` | New reusable class component |
| `App.tsx` | Wrap CartPage Suspense; add `CartLoadError` fallback component |
| `HomePage.tsx` | Wrap each modal Suspense with `ErrorBoundary` |
| `en.json` / `es.json` | Add `common.loadError` key |

## Test plan
- [x] Normal flow: home page loads, modals open, cart page loads — no change
- [x] Simulate chunk failure: in DevTools Network tab, block a `.js` chunk request → CartPage shows error UI instead of blank screen; modals fail silently
- [x] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)