### PR TITLE
feat: focus trap en modales para accesibilidad de teclado

### DIFF
--- a/src/application/hooks/useFocusTrap.ts
+++ b/src/application/hooks/useFocusTrap.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export function useFocusTrap(isOpen: boolean, onClose: () => void) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!isOpen || !containerRef.current) return;
+
+    const container = containerRef.current;
+    const previousFocus = document.activeElement as HTMLElement | null;
+
+    // Move focus to first focusable element when modal opens
+    const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE);
+    focusable[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCloseRef.current();
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      const elements = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (elements.length === 0) return;
+
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousFocus?.focus();
+    };
+  }, [isOpen]);
+
+  return containerRef;
+}

--- a/src/presentation/components/LoginModal.tsx
+++ b/src/presentation/components/LoginModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../../application/hooks/useAuth';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
+import { useFocusTrap } from '../../application/hooks/useFocusTrap';
 
 interface LoginModalProps {
   isOpen: boolean;
@@ -50,6 +51,8 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
     onShowRegister();
   };
 
+  const containerRef = useFocusTrap(isOpen, handleClose);
+
   if (!isOpen) return null;
 
   return (
@@ -59,6 +62,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister
 
       {/* Modal */}
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="login-modal-title"

--- a/src/presentation/components/LoginModal.tsx
+++ b/src/presentation/components/LoginModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../application/hooks/useAuth';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
 import { useFocusTrap } from '../../application/hooks/useFocusTrap';
@@ -12,6 +13,7 @@ interface LoginModalProps {
 import { FaSignInAlt, FaTimes, FaEnvelope, FaLock, FaSpinner } from 'react-icons/fa';
 
 const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onShowRegister }) => {
+  const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/src/presentation/components/OrdersModal.tsx
+++ b/src/presentation/components/OrdersModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../application/hooks/useAuth';
 import { FaShoppingBag, FaTimes } from 'react-icons/fa';
+import { useFocusTrap } from '../../application/hooks/useFocusTrap';
 
 interface Order {
   id: string;
@@ -28,11 +29,14 @@ const OrdersModal: React.FC<OrdersModalProps> = ({ isOpen, onClose }) => {
   // TODO: Fetch orders from backend
   const orders: Order[] = [];
 
+  const containerRef = useFocusTrap(isOpen, onClose);
+
   if (!isOpen || !user) return null;
 
   return (
     <div className="fixed inset-0 bg-dark/80 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={onClose}>
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="orders-modal-title"

--- a/src/presentation/components/ProfileModal.tsx
+++ b/src/presentation/components/ProfileModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../application/hooks/useAuth';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
+import { useFocusTrap } from '../../application/hooks/useFocusTrap';
 
 interface ProfileModalProps {
   isOpen: boolean;
@@ -59,11 +60,14 @@ const ProfileModal: React.FC<ProfileModalProps> = ({ isOpen, onClose }) => {
     onClose();
   };
 
+  const containerRef = useFocusTrap(isOpen, handleClose);
+
   if (!isOpen || !user) return null;
 
   return (
     <div className="fixed inset-0 bg-dark/80 backdrop-blur-sm flex items-center justify-center p-4 z-50" onClick={handleClose}>
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="profile-modal-title"

--- a/src/presentation/components/RegisterModal.tsx
+++ b/src/presentation/components/RegisterModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../../application/hooks/useAuth';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
+import { useFocusTrap } from '../../application/hooks/useFocusTrap';
 
 interface RegisterModalProps {
   isOpen: boolean;
@@ -108,6 +109,8 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
     onShowLogin();
   };
 
+  const containerRef = useFocusTrap(isOpen, handleClose);
+
   if (!isOpen) return null;
 
   const inputClass = (field: string) =>
@@ -122,6 +125,7 @@ const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLo
 
       {/* Modal */}
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="register-modal-title"

--- a/src/presentation/components/RegisterModal.tsx
+++ b/src/presentation/components/RegisterModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../application/hooks/useAuth';
 import { NotificationManager } from '../../infrastructure/services/NotificationManager';
 import { useFocusTrap } from '../../application/hooks/useFocusTrap';
@@ -12,6 +13,7 @@ interface RegisterModalProps {
 import { FaUserPlus, FaTimes, FaUser, FaEnvelope, FaLock, FaBuilding, FaPhone, FaSpinner } from 'react-icons/fa';
 
 const RegisterModal: React.FC<RegisterModalProps> = ({ isOpen, onClose, onShowLogin }) => {
+  const { t } = useTranslation();
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',

--- a/src/presentation/components/ServiceDetailModal.tsx
+++ b/src/presentation/components/ServiceDetailModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Service } from '../../domain/entities/Service';
 import { faIconMap } from '../utils/faIconMap';
+import { useFocusTrap } from '../../application/hooks/useFocusTrap';
 
 interface ServiceDetailModalProps {
   isOpen: boolean;
@@ -19,6 +20,8 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
   onAddToCart
 }) => {
   const { t } = useTranslation();
+  const containerRef = useFocusTrap(isOpen, onClose);
+
   if (!isOpen || !service) return null;
 
   const handleAddToCart = () => {
@@ -46,6 +49,7 @@ const ServiceDetailModal: React.FC<ServiceDetailModalProps> = ({
 
       {/* Modal */}
       <div
+        ref={containerRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="service-modal-title"


### PR DESCRIPTION
## Summary

- Nuevo hook `useFocusTrap` en `src/application/hooks/useFocusTrap.ts`
- Tab / Shift+Tab quedan atrapados dentro del modal activo
- Al abrir, el foco salta automáticamente al primer elemento interactivo
- Escape cierra el modal y restaura el foco al elemento que lo abrió
- Aplicado a los 5 modales: LoginModal, RegisterModal, ProfileModal, OrdersModal, ServiceDetailModal
- ProfileModal usa `handleClose` (no `onClose`) para resetear el estado de edición al presionar Escape

## Test plan

- [x] Abrir Login → Tab debe ciclar sólo dentro del modal → Escape lo cierra y el foco vuelve al botón que lo abrió
- [x] Abrir Register → mismo comportamiento de Tab/Escape
- [x] Abrir Perfil en modo vista → Escape cierra; abrir en modo edición → Escape cierra Y resetea el formulario
- [x] Abrir Pedidos → Tab cicla dentro, Escape cierra
- [x] Abrir detalle de servicio → Tab cicla dentro, Escape cierra
- [x] `npm run build` pasa sin errores ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)