### PR TITLE
feat: título dinámico del documento por ruta

### DIFF
--- a/src/application/hooks/useDocumentTitle.ts
+++ b/src/application/hooks/useDocumentTitle.ts
@@ -1,0 +1,7 @@
+import { useEffect } from 'react';
+
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -232,6 +232,10 @@
     "available": "Available Now",
     "unavailable": "Not Available"
   },
+  "meta": {
+    "titleHome": "Juan José Hernández | Development Consultant & Technology",
+    "titleCart": "Cart | Juan José Hernández"
+  },
   "common": {
     "loading": "Loading...",
     "loadError": "Failed to load. Try refreshing the page.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -232,6 +232,10 @@
     "available": "Disponible Ahora",
     "unavailable": "No Disponible"
   },
+  "meta": {
+    "titleHome": "Juan José Hernández | Consultor de Desarrollo y Tecnología",
+    "titleCart": "Carrito | Juan José Hernández"
+  },
   "common": {
     "loading": "Cargando...",
     "loadError": "Error al cargar. Intenta recargar la página.",

--- a/src/presentation/pages/CartPage.tsx
+++ b/src/presentation/pages/CartPage.tsx
@@ -2,6 +2,7 @@ import { FaArrowLeft, FaShoppingCart, FaTrash, FaSearch, FaList, FaClock, FaEdit
 import { faIconMap } from '../utils/faIconMap';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDocumentTitle } from '../../application/hooks/useDocumentTitle';
 import { useCart } from '../../application/hooks/useCart';
 import { useAuth } from '../../application/hooks/useAuth';
 import { useModal } from '../../application/context/ModalContext';
@@ -12,6 +13,7 @@ import RegisterModal from '../components/RegisterModal';
 
 const CartPage: React.FC = () => {
   const { t } = useTranslation();
+  useDocumentTitle(t('meta.titleCart'));
   const { items, totalAmount, updateQuantity, removeFromCart, clearCart } = useCart();
   const { isAuthenticated } = useAuth();
   const { 

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import React, { lazy, Suspense, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import ErrorBoundary from '../components/ErrorBoundary';
 import Navigation from '../components/Navigation.tsx';
@@ -10,6 +11,7 @@ import Experience from '../components/Experience.tsx';
 import Contact from '../components/Contact.tsx';
 import Footer from '../components/Footer.tsx';
 import { useModal } from '../../application/context/ModalContext';
+import { useDocumentTitle } from '../../application/hooks/useDocumentTitle';
 
 const LoginModal = lazy(() => import('../components/LoginModal.tsx'));
 const RegisterModal = lazy(() => import('../components/RegisterModal.tsx'));
@@ -17,6 +19,8 @@ const ProfileModal = lazy(() => import('../components/ProfileModal.tsx'));
 const OrdersModal = lazy(() => import('../components/OrdersModal.tsx'));
 
 const HomePage: React.FC = () => {
+  const { t } = useTranslation();
+  useDocumentTitle(t('meta.titleHome'));
   const location = useLocation();
   const {
     isLoginOpen,


### PR DESCRIPTION
## Summary

- Nuevo hook `useDocumentTitle(title: string)` en `src/application/hooks/useDocumentTitle.ts`
- `HomePage` → **"Juan José Hernández | Consultor de Desarrollo y Tecnología"** (ES) / **"... | Development Consultant & Technology"** (EN)
- `CartPage` → **"Carrito | Juan José Hernández"** (ES) / **"Cart | Juan José Hernández"** (EN)
- Títulos respetan el idioma activo via nuevas claves i18n `meta.titleHome` y `meta.titleCart`

## Test plan

- [x] Navegar a `/` → pestaña del browser muestra el título de la home
- [x] Navegar a `/carrito` → pestaña muestra "Carrito | Juan José Hernández"
- [x] Cambiar idioma a EN → título se actualiza al inglés en ambas rutas
- [x] `npm run build` pasa sin errores ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)