### PR TITLE
SEO: nuevos servicios en datos estructurados (JSON-LD) y llms.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,11 @@
               { "@type": "Offer", "priceCurrency": "USD", "price": "5500", "itemOffered": { "@type": "Service", "name": "CMS Headless con Strapi en AWS", "description": "Strapi CMS con arquitectura enterprise en AWS: CloudFront, ECS Fargate, Aurora, S3 y seguridad." } },
               { "@type": "Offer", "priceCurrency": "USD", "price": "6800", "itemOffered": { "@type": "Service", "name": "Infraestructura como Código Multi-Cloud", "description": "IaC con Terraform para AWS, Azure y GCP con CI/CD completo y módulos reutilizables." } },
               { "@type": "Offer", "priceCurrency": "USD", "price": "4200", "itemOffered": { "@type": "Service", "name": "Auditoría de Ciberseguridad y Pentesting", "description": "Análisis de vulnerabilidades, pentesting, auditoría de código y plan de remediación OWASP." } },
-              { "@type": "Offer", "priceCurrency": "USD", "itemOffered": { "@type": "Service", "name": "Integración de IA y agentes (MCP)", "description": "Diseño y despliegue de servidores MCP, agentes y skills para automatizar procesos y conectar herramientas internas con modelos de lenguaje." } }
+              { "@type": "Offer", "priceCurrency": "USD", "itemOffered": { "@type": "Service", "name": "Integración de IA y agentes (MCP)", "description": "Diseño y despliegue de servidores MCP, agentes y skills para automatizar procesos y conectar herramientas internas con modelos de lenguaje." } },
+              { "@type": "Offer", "priceCurrency": "USD", "price": "2800", "itemOffered": { "@type": "Service", "name": "Observabilidad y Monitoreo (SRE)", "description": "Implementación de logs, métricas, dashboards y alertas con Grafana, Prometheus, CloudWatch, Datadog y Loki; guardias on-call y detección temprana de fallos." } },
+              { "@type": "Offer", "priceCurrency": "USD", "price": "5000", "itemOffered": { "@type": "Service", "name": "Integración Bancaria y Open Banking", "description": "Open Banking / Open Finance: agregación de datos financieros, integración con bancos, scrapers y bots de autenticación con arquitectura hexagonal." } },
+              { "@type": "Offer", "priceCurrency": "USD", "price": "1500", "itemOffered": { "@type": "Service", "name": "Facturación Electrónica (SAT / e-Factura)", "description": "Integración de facturación electrónica ante la SAT directamente en aplicaciones web y móviles, conectada al flujo de ventas." } },
+              { "@type": "Offer", "priceCurrency": "USD", "price": "7500", "itemOffered": { "@type": "Service", "name": "Modernización de Sistemas Legacy", "description": "Migración por fases de monolitos y sistemas legacy a microservicios con Clean Architecture, contenedores y CI/CD, sin detener la operación." } }
             ]
           }
         },
@@ -179,6 +183,10 @@
           <li><strong>Auditoría de Ciberseguridad y Pentesting</strong>: análisis de vulnerabilidades, pentesting y remediación OWASP.</li>
           <li><strong>Consultoría Tecnológica</strong>: arquitectura, selección de stack, auditorías y optimización de procesos.</li>
           <li><strong>Integración de IA y agentes (MCP)</strong>: servidores MCP, agentes y skills para automatizar procesos y conectar herramientas internas con modelos de lenguaje.</li>
+          <li><strong>Observabilidad y Monitoreo (SRE)</strong>: logs, métricas, dashboards y alertas con Grafana, Prometheus, CloudWatch, Datadog y Loki; guardias on-call.</li>
+          <li><strong>Integración Bancaria y Open Banking</strong>: Open Banking / Open Finance, agregación de datos financieros e integración con bancos.</li>
+          <li><strong>Facturación Electrónica (SAT / e-Factura)</strong>: emisión integrada a aplicaciones web y móviles, conectada al flujo de ventas.</li>
+          <li><strong>Modernización de Sistemas Legacy</strong>: migración por fases de monolitos a microservicios con Clean Architecture y CI/CD, sin detener la operación.</li>
           <li><strong>Capacitación Técnica</strong>: workshops y mentoría en tecnologías modernas, cloud y metodologías ágiles.</li>
         </ul>
 
@@ -195,7 +203,7 @@
         <ul>
           <li>Sistema de Gestión Empresarial con factura electrónica SAT (Distribuidora Don Julio, Guatemala).</li>
           <li>Plataforma multi-cliente con integración de couriers y facturación electrónica (QuickComm, Perú/Argentina).</li>
-          <li>Aplicativo bancario SPA y móvil (Menoo App, Uruguay).</li>
+          <li>Aplicativo de gestión administrativa y factura electrónica, SPA y móvil (Menoo App, Uruguay).</li>
           <li>Sistemas financieros con integración a banca virtual Banrural (Technology Center, Guatemala).</li>
           <li>Ventanilla Única Virtual para trámites municipales (USAID / Municipalidad de Villa Nueva, Guatemala).</li>
         </ul>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -40,7 +40,11 @@ C#/.NET y .NET Core, TypeScript, JavaScript, Node.js (Express, NestJS, AdonisJS)
 - CMS Headless con Strapi en AWS — desde USD 5,500. Arquitectura enterprise: CloudFront, ECS Fargate, Aurora, S3.
 - Infraestructura como Código Multi-Cloud — desde USD 6,800. Terraform para AWS, Azure y GCP con CI/CD.
 - Auditoría de Ciberseguridad y Pentesting — desde USD 4,200. Vulnerabilidades, pentesting y remediación OWASP.
-- Integración de IA y agentes (MCP) — diseño y despliegue de servidores MCP, agentes y skills.
+- Integración de IA y agentes (MCP) — por hora. Diseño y despliegue de servidores MCP, agentes y skills.
+- Observabilidad y Monitoreo (SRE) — desde USD 2,800. Logs, métricas, dashboards y alertas con Grafana, Prometheus, CloudWatch, Datadog y Loki; on-call.
+- Integración Bancaria y Open Banking — desde USD 5,000. Open Banking / Open Finance, agregación de datos financieros e integración con bancos.
+- Facturación Electrónica (SAT / e-Factura) — desde USD 1,500. Emisión integrada a aplicaciones web y móviles, conectada al flujo de ventas.
+- Modernización de Sistemas Legacy — desde USD 7,500. Migración por fases de monolitos y legacy a microservicios, sin detener la operación.
 - Desarrollo de APIs — desde USD 1,800. REST y GraphQL escalables y seguras.
 - Soluciones E-commerce — desde USD 3,200. Tiendas online con pasarelas de pago.
 - Diseño de Base de Datos — desde USD 800. Modelado, optimización y migraciones.


### PR DESCRIPTION
## Datos estructurados + llms.txt — nuevos servicios

Sincroniza los datos que leen **buscadores y agentes IA** con el catálogo ya mergeado (PR #38), agregando los 4 servicios nuevos derivados de los CVs.

### index.html
- **JSON-LD `OfferCatalog`**: de 9 a 13 ofertas. Añadidas: Observabilidad y Monitoreo (SRE, USD 2,800), Integración Bancaria / Open Banking (USD 5,000), Facturación Electrónica SAT (USD 1,500) y Modernización de Sistemas Legacy (USD 7,500).
- **Bloque `<noscript>`**: los mismos 4 servicios en la lista indexable por crawlers sin JS.
- **Fix**: Menoo App descrito como gestión administrativa + e-Factura (ya no "bancario").

### public/llms.txt
- Añadidos los 4 servicios al resumen para agentes IA.

### Verificación
- JSON-LD válido (parseo OK, 13 offers) y `npm run build` ✅ (exit 0).
- base: `develop`.

🤖 Generated with Claude
