### PR TITLE
fix(seo): contacto y skills indexables (footer + noscript)

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,18 @@
           Infrastructure as Code con Terraform, observabilidad e integración de IA aplicada al
           desarrollo: diseño y despliegue de servidores MCP (Model Context Protocol), agentes y skills.
         </p>
-        <p>Contacto: ju16jo@gmail.com · +502 3132-2197 · Guatemala · Disponible para proyectos remotos en LATAM.</p>
+        <p>
+          Contacto:
+          <a href="mailto:ju16jo@gmail.com">ju16jo@gmail.com</a> ·
+          <a href="tel:+50231322197">+502 3132-2197</a> ·
+          Guatemala · Disponible para proyectos remotos en LATAM.
+        </p>
+        <p>
+          Redes:
+          <a href="https://github.com/jose16-21">GitHub: jose16-21</a> ·
+          <a href="https://www.linkedin.com/in/juan-jose-hernandez-gt/">LinkedIn: Juan José Hernández</a> ·
+          <a href="https://jose16-21.github.io">jose16-21.github.io</a>
+        </p>
 
         <h2>Servicios</h2>
         <ul>
@@ -208,13 +219,25 @@
           <li>Ventanilla Única Virtual para trámites municipales (USAID / Municipalidad de Villa Nueva, Guatemala).</li>
         </ul>
 
-        <h2>Instituciones y marcas atendidas</h2>
+        <h2>Tecnologías y stack</h2>
         <p>
-          Instituciones para las que se han desarrollado soluciones, en su mayoría como parte
-          de equipos o esquemas de outsourcing: Banco Industrial, BAC Credomatic, Banrural,
-          Bancolombia, Génesis Empresarial, Finerio Connect, Rappi, Vía Compras, Shopstart,
-          Distribuidora Don Julio, Distribuidora Anabel, Menoo, la Municipalidad de Villa Nueva y USAID.
-          Las marcas pertenecen a sus respectivos titulares.
+          Lenguajes y frameworks: C#/.NET y .NET Core, TypeScript, JavaScript, Node.js
+          (Express, NestJS, AdonisJS), Python, Angular, React, Vue, Ionic, Flutter.
+        </p>
+        <p>
+          Cloud y DevOps: AWS (EC2, EKS, Lambda, S3, RDS, DynamoDB), Azure (AKS, DevOps),
+          Docker, Kubernetes, Terraform, CloudFormation, CI/CD (GitHub Actions, Azure DevOps, Jenkins),
+          Apache Kafka, Krakend Gateway.
+        </p>
+        <p>
+          Observabilidad: Grafana, Prometheus, CloudWatch, Datadog, Loki, cAdvisor, Opsgenie.
+        </p>
+        <p>
+          Bases de datos: SQL Server, PostgreSQL, MySQL, MongoDB, DynamoDB, Cosmos DB, Firebase, Redis.
+        </p>
+        <p>
+          IA aplicada al desarrollo: servidores MCP (Model Context Protocol), agentes y skills;
+          Claude Code, Codex y GitHub Copilot integrados al flujo de trabajo.
         </p>
 
         <p>Más información estructurada para agentes en <a href="https://jose16-21.github.io/llms.txt">/llms.txt</a>.</p>

--- a/src/presentation/components/Footer.tsx
+++ b/src/presentation/components/Footer.tsx
@@ -39,7 +39,7 @@ const Footer: React.FC = () => {
       links: [
         { icon: <FaEnvelope />, text: 'ju16jo@gmail.com', href: 'mailto:ju16jo@gmail.com', copyable: true },
         { icon: <FaPhone />, text: '+502 3132-2197', href: 'tel:+50231322197', copyable: true },
-        { icon: <FaMapMarkerAlt />, text: 'Guatemala', href: '#', copyable: false }
+        { icon: <FaMapMarkerAlt />, text: 'Guatemala', href: null, copyable: false }
       ]
     }
   ];
@@ -54,12 +54,15 @@ const Footer: React.FC = () => {
             <div className="flex gap-4 mt-4">
               <a href="mailto:ju16jo@gmail.com" aria-label="Email" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
                 <FaEnvelope />
+                <span className="sr-only">Email: ju16jo@gmail.com</span>
               </a>
               <a href="https://www.linkedin.com/in/juan-jose-hernandez-gt/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
                 <FaLinkedin />
+                <span className="sr-only">LinkedIn: Juan José Hernández</span>
               </a>
               <a href="https://github.com/jose16-21" aria-label="GitHub" target="_blank" rel="noopener noreferrer" className="w-10 h-10 bg-primary-light rounded-full flex items-center justify-center transition-all hover:bg-secondary hover:text-white">
                 <FaGithub />
+                <span className="sr-only">GitHub: jose16-21</span>
               </a>
             </div>
           </div>
@@ -71,9 +74,18 @@ const Footer: React.FC = () => {
                   <li key={index} className="mb-2">
                     {'icon' in link ? (
                       <div className="flex items-center gap-2 justify-between group">
-                        <span className="cursor-pointer transition-colors hover:text-secondary font-light">
-                          {link.icon} {link.text}
-                        </span>
+                        {link.href ? (
+                          <a
+                            href={link.href}
+                            className="flex items-center gap-2 transition-colors hover:text-secondary font-light no-underline"
+                          >
+                            {link.icon} {link.text}
+                          </a>
+                        ) : (
+                          <span className="flex items-center gap-2 transition-colors font-light">
+                            {link.icon} {link.text}
+                          </span>
+                        )}
                         {link.copyable && (
                           <button
                             className="bg-primary-light text-gray-light border-none rounded px-2 py-1 cursor-pointer transition-all flex items-center justify-center w-7 h-7 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 hover:bg-secondary hover:text-white active:scale-95"


### PR DESCRIPTION
## Problema

Las secciones de **skills/tecnologías** y los **contactos** (teléfono, GitHub, LinkedIn) no eran localizables para buscadores/agentes IA cuando no se ejecutaba JavaScript: el teléfono y el email estaban como texto plano (sin `tel:`/`mailto:`), las redes solo como iconos, y la sección de tecnologías **no existía** en el fallback `noscript`.

## Cambios

### Footer (`Footer.tsx`)
- Email y teléfono ahora son **enlaces reales** (`mailto:` / `tel:`) en vez de texto no clicable; se conserva el botón de copiar.
- Iconos sociales (Email/LinkedIn/GitHub) con etiqueta `sr-only` para que la extracción de texto identifique cada red sin alterar el diseño.

### Fallback `noscript` (`index.html`)
- Contacto con enlaces reales (`mailto`/`tel`) + bloque de **Redes** (GitHub, LinkedIn, sitio).
- Nueva sección **'Tecnologías y stack'** (lenguajes, cloud/DevOps, observabilidad, bases de datos, IA/MCP) que antes no aparecía.

## Verificación

`npm run build` (con prerender) exitoso. En `dist/index.html` ahora aparecen:
- `tel:+50231322197` y `mailto:ju16jo@gmail.com` (antes `tel:` = 0).
- Enlaces a GitHub y LinkedIn con texto.
- Sección 'Tecnologías y stack' en el `noscript`.

> Nota: el JSON-LD `Person.knowsAbout` ya cubría las skills en formato estructurado; no se modificó.